### PR TITLE
[fix] - added a post installation script in composer.json which creat…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,8 @@
     "fix": "psalter --issues=all",
     "format": "php-cs-fixer fix --rules=@PSR12,@Symfony,declare_strict_types --allow-risky=yes .",
     "post-root-package-install": [
-      "@php -r \"file_exists('.env') || copy('env.example', '.env');\""
+      "@php -r \"file_exists('.env') || copy('env.example', '.env');\"",
+      "@php -r \"if (!file_exists('var/logs')) { mkdir('var/logs', 0777, true); } touch('var/logs/app.log');\""
     ],
     "update-framework": [
       "upgrader upgrade-safely"


### PR DESCRIPTION
## Description

Introduced one more post-installation step in the _composer.json_, which will add the _var/_ directory and create _app.log_ if it does not exist.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I ran the script manually to see if it will create the directory with the file.
