### PR TITLE
feat: adds a simple in memory cache implementing Psr standard

### DIFF
--- a/src/Config/services.json
+++ b/src/Config/services.json
@@ -143,6 +143,17 @@
       }
     },
     {
+      "name": "CubaDevOps\\Flexi\\Infrastructure\\Classes\\InMemoryCache",
+      "class": {
+        "name": "CubaDevOps\\Flexi\\Infrastructure\\Classes\\InMemoryCache",
+        "arguments": []
+      }
+    },
+    {
+      "name": "cache",
+      "alias": "CubaDevOps\\Flexi\\Infrastructure\\Classes\\InMemoryCache"
+    },
+    {
       "glob": "./modules/*/Config/services.json"
     }
   ]

--- a/src/Domain/Interfaces/CacheInterface.php
+++ b/src/Domain/Interfaces/CacheInterface.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace CubaDevOps\Flexi\Domain\Interfaces;
 
-interface CacheInterface
+interface CacheInterface extends \Psr\SimpleCache\CacheInterface
 {
 }

--- a/src/Infrastructure/Classes/InMemoryCache.php
+++ b/src/Infrastructure/Classes/InMemoryCache.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace CubaDevOps\Flexi\Infrastructure\Classes;
+
+use CubaDevOps\Flexi\Domain\Exceptions\InvalidArgumentCacheException;
+use CubaDevOps\Flexi\Domain\Interfaces\CacheInterface;
+
+class InMemoryCache implements CacheInterface
+{
+
+    private array $cache;
+
+    public function __construct()
+    {
+        $this->cache = [];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function clear(): bool
+    {
+        $this->cache = [];
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getMultiple($keys, $default = null): iterable
+    {
+        $this->assertIsIterable($keys);
+        return array_map(function ($key) use ($default) {
+            return $this->get($key, $default);
+        }, (array)$keys);
+    }
+
+    /**
+     * @param mixed $values
+     * @return void
+     * @throws InvalidArgumentCacheException
+     */
+    private function assertIsIterable($values): void
+    {
+        if (!is_iterable($values)) {
+            throw new InvalidArgumentCacheException("Values must be an iterable");
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function get($key, $default = null)
+    {
+        $this->assertIsValidKey($key);
+        return $this->cache[$key] ?? $default;
+    }
+
+    /**
+     * @param mixed $key
+     * @return void
+     * @throws InvalidArgumentCacheException
+     */
+    private function assertIsValidKey($key): void
+    {
+        if (!is_string($key) || strlen($key) > 100) {
+            throw new InvalidArgumentCacheException("Key must be a string with a maximum length of 100 characters");
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setMultiple($values, $ttl = null): bool
+    {
+        $this->assertIsIterable($values);
+
+        $result = true;
+        foreach ($values as $key => $value) {
+            $result &= $this->set($key, $value, $ttl);
+        }
+        return $result;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function set($key, $value, $ttl = null): bool
+    {
+        $this->assertIsValidKey($key);
+        $this->cache[$key] = $value;
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function deleteMultiple($keys): bool
+    {
+        $this->assertIsIterable($keys);
+
+        $result = true;
+        foreach ((array)$keys as $key) {
+            $result &= $this->delete($key);
+        }
+        return $result;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function delete($key): bool
+    {
+        $this->assertIsValidKey($key);
+
+        if (!$this->has($key)) {
+            return false;
+        }
+        unset($this->cache[$key]);
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function has($key): bool
+    {
+        $this->assertIsValidKey($key);
+        return isset($this->cache[$key]);
+    }
+}

--- a/tests/Infrastructure/Classes/InMemoryCacheTest.php
+++ b/tests/Infrastructure/Classes/InMemoryCacheTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace CubaDevOps\Flexi\Test\Infrastructure\Classes;
+
+use CubaDevOps\Flexi\Domain\Exceptions\InvalidArgumentCacheException;
+use CubaDevOps\Flexi\Infrastructure\Classes\InMemoryCache;
+use PHPUnit\Framework\TestCase;
+
+class InMemoryCacheTest extends TestCase
+{
+    public function testDeleteMultiple()
+    {
+        $this->cache->set('key1', 'value1');
+        $this->cache->set('key2', 'value2');
+        $this->cache->deleteMultiple(['key1', 'key2']);
+
+        $this->assertEmpty($this->cache->get('key1'));
+        $this->assertEmpty($this->cache->get('key2'));
+    }
+
+    public function testDeleteMultipleThrowAnExceptionWithInvalidKey()
+    {
+        $this->expectException(InvalidArgumentCacheException::class);
+        $this->cache->deleteMultiple([1]);
+    }
+
+    public function testDelete()
+    {
+        $this->cache->set('key', 'value');
+        $this->cache->delete('key');
+        $this->assertEmpty($this->cache->get('key'));
+    }
+
+    public function testDeleteThrowAnExceptionWithInvalidKey()
+    {
+        $this->expectException(InvalidArgumentCacheException::class);
+        $this->cache->delete(1);
+    }
+
+    public function testClear()
+    {
+        $this->cache->set('key', 'value');
+        $this->cache->clear();
+        $this->assertEmpty($this->cache->get('key'));
+    }
+
+    public function testSetMultiple()
+    {
+        $this->cache->setMultiple(['key1' => 'value1', 'key2' => 'value2']);
+        $this->assertEquals('value1', $this->cache->get('key1'));
+        $this->assertEquals('value2', $this->cache->get('key2'));
+    }
+
+    public function testSetMultipleThrowAnExceptionWithInvalidKey()
+    {
+        $this->expectException(InvalidArgumentCacheException::class);
+        $this->cache->setMultiple([1]);
+    }
+
+    public function testSetMultipleThrowAnExceptionWithInvalidParam()
+    {
+        $this->expectException(InvalidArgumentCacheException::class);
+        $this->cache->setMultiple(1);
+    }
+
+    public function testHas()
+    {
+        $this->cache->set('key', 'value');
+        $this->assertTrue($this->cache->has('key'));
+    }
+
+    public function testHasThrowAnExceptionWithInvalidKey()
+    {
+        $this->expectException(InvalidArgumentCacheException::class);
+        $this->cache->has(1);
+    }
+
+    public function testGetMultiple()
+    {
+        $this->cache->set('key1', 'value1');
+        $this->cache->set('key2', 'value2');
+        $this->assertEquals(['value1', 'value2'], $this->cache->getMultiple(['key1', 'key2']));
+    }
+
+    public function testGetMultipleThrowAnExceptionWithInvalidKey()
+    {
+        $this->expectException(InvalidArgumentCacheException::class);
+        $this->cache->getMultiple([1]);
+    }
+
+    public function testGet()
+    {
+        $this->cache->set('key', 'value');
+        $this->assertEquals('value', $this->cache->get('key'));
+    }
+
+    public function testGetThrowAnExceptionWithInvalidKey()
+    {
+        $this->expectException(InvalidArgumentCacheException::class);
+        $this->cache->get(1);
+    }
+
+    public function testSet()
+    {
+        $this->cache->set('key', 'value');
+        $this->assertEquals('value', $this->cache->get('key'));
+    }
+
+    public function testSetThrowAnExceptionWithInvalidKey()
+    {
+        $this->expectException(InvalidArgumentCacheException::class);
+        $this->cache->set(1, 2);
+    }
+
+    protected function setUp(): void
+    {
+        $this->cache = new InMemoryCache();
+    }
+}


### PR DESCRIPTION
## Description

Flexi needs a caching system to improve performance and avoid double instantiation of classes in some areas

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] Unit Tests

**Test Configuration**:
* Flexi version: dev
* PHP version: 7.4
* Operating System: MacOs

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional Information

It should be used/implemented in ClassFactory and in query or read operations.
