### PR TITLE
fix: wrong namespace used to instantiate ContainerFactory in Router class

### DIFF
--- a/src/Domain/Classes/Router.php
+++ b/src/Domain/Classes/Router.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CubaDevOps\Flexi\Domain\Classes;
 
-use CubaDevOps\Flexi\Domain\Factories\ContainerFactory;
+use CubaDevOps\Flexi\Infrastructure\Factories\ContainerFactory;
 use CubaDevOps\Flexi\Domain\Interfaces\EventBusInterface;
 use CubaDevOps\Flexi\Domain\Interfaces\SessionStorageInterface;
 use CubaDevOps\Flexi\Domain\Utils\ClassFactory;

--- a/src/Infrastructure/Cache/InMemoryCache.php
+++ b/src/Infrastructure/Cache/InMemoryCache.php
@@ -71,7 +71,7 @@ class InMemoryCache implements CacheInterface
             $result &= $this->set($key, $value, $ttl);
         }
 
-        return $result;
+        return (bool)$result;
     }
 
     public function set($key, $value, $ttl = null): bool
@@ -91,7 +91,7 @@ class InMemoryCache implements CacheInterface
             $result &= $this->delete($key);
         }
 
-        return $result;
+        return (bool)$result;
     }
 
     public function delete($key): bool

--- a/tests/Domain/Classes/ContainerTest.php
+++ b/tests/Domain/Classes/ContainerTest.php
@@ -16,6 +16,7 @@ use CubaDevOps\Flexi\Domain\Classes\VersionRepository;
 use CubaDevOps\Flexi\Domain\Utils\ClassFactory;
 use CubaDevOps\Flexi\Domain\ValueObjects\ServiceType;
 use CubaDevOps\Flexi\Infrastructure\Classes\Configuration;
+use CubaDevOps\Flexi\Infrastructure\Factories\CacheFactory;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
@@ -34,7 +35,7 @@ class ContainerTest extends TestCase
      */
     public function setUp(): void
     {
-        $this->container = new Container();
+        $this->container = new Container(CacheFactory::getInstance());
 
         $this->container->loadServices('./src/Config/services.json');
     }

--- a/tests/Domain/Utils/ClassFactoryTest.php
+++ b/tests/Domain/Utils/ClassFactoryTest.php
@@ -2,11 +2,12 @@
 
 namespace CubaDevOps\Flexi\Test\Domain\Utils;
 
-use CubaDevOps\Flexi\Domain\Factories\ContainerFactory;
 use CubaDevOps\Flexi\Domain\Factories\RouterFactory;
 use CubaDevOps\Flexi\Domain\Utils\ClassFactory;
 use CubaDevOps\Flexi\Infrastructure\Classes\Configuration;
 use CubaDevOps\Flexi\Infrastructure\Factories\ConfigurationFactory;
+use CubaDevOps\Flexi\Infrastructure\Factories\ContainerFactory;
+use CubaDevOps\Flexi\Infrastructure\Factories\CacheFactory;
 use CubaDevOps\Flexi\Test\TestData\TestDoubles\HasNoConstructor;
 use CubaDevOps\Flexi\Test\TestData\TestDoubles\IsNotInstantiable;
 use PHPUnit\Framework\TestCase;
@@ -19,7 +20,7 @@ class ClassFactoryTest extends TestCase
 
     public function setUp(): void
     {
-        $this->classFactory = new ClassFactory();
+        $this->classFactory = new ClassFactory(CacheFactory::getInstance());
 
         $this->container = ContainerFactory::getInstance('./tests/TestData/Configurations/container-test.json');
     }

--- a/tests/Infrastructure/Cache/InMemoryCacheTest.php
+++ b/tests/Infrastructure/Cache/InMemoryCacheTest.php
@@ -1,13 +1,16 @@
 <?php
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\Classes;
+namespace CubaDevOps\Flexi\Test\Infrastructure\Cache;
 
 use CubaDevOps\Flexi\Domain\Exceptions\InvalidArgumentCacheException;
-use CubaDevOps\Flexi\Infrastructure\Classes\InMemoryCache;
+use CubaDevOps\Flexi\Domain\Interfaces\CacheInterface;
+use CubaDevOps\Flexi\Infrastructure\Cache\InMemoryCache;
 use PHPUnit\Framework\TestCase;
 
 class InMemoryCacheTest extends TestCase
 {
+    private CacheInterface $cache;
+
     public function testDeleteMultiple()
     {
         $this->cache->set('key1', 'value1');


### PR DESCRIPTION
## Description

Fixes #54 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit Tests
- [x] Integration Tests

**Test Configuration**:
* Flexi version: dev
* PHP version: 7.4
* Operating System: MacOs

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes