### PR TITLE
chore: add empty modules directory for framework structure

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -131,6 +131,26 @@ jobs:
           # Push usando el token directo (asegúrate de que secrets.GIT_TOKEN exista y tenga scope repo si es PAT)
           git push origin HEAD:main
 
+      - name: Sync develop branch with main
+        if: ${{ steps.check_release.outputs.released == 'true' }}
+        run: |
+          echo "=== Sincronizando rama develop con main ==="
+
+          # Fetch todas las ramas
+          git fetch origin
+
+          # Checkout a develop
+          git checkout develop
+          git pull origin develop
+
+          # Rebase main sobre develop
+          git rebase origin/main
+
+          # Push de los cambios a develop
+          git push origin develop
+
+          echo "=== Rama develop actualizada y sincronizada con main ==="
+
       - name: Format Code
         if: ${{ steps.check_release.outputs.released == 'true' }}
         run: composer run-script format

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 .env.testing
 vendor
 var
-modules
+modules/*
+!modules/.gitkeep
 xdebug
 *.cache
 *.log

--- a/modules/.gitkeep
+++ b/modules/.gitkeep
@@ -1,0 +1,3 @@
+# Este directorio está destinado a alojar módulos del framework Flexi
+# Los módulos ahora se gestionan como paquetes independientes vía Composer
+# Para más información, consulta la documentación sobre el sistema modular


### PR DESCRIPTION
This pull request introduces an automated workflow improvement and documentation update to support better branch management and clarify the purpose of the `modules` directory.

**Workflow automation:**

* Added a step in `.github/workflows/semver.yml` to automatically sync the `develop` branch with `main` after a release is detected, ensuring both branches remain up to date and reducing manual intervention.

**Documentation update:**

* Updated `modules/.gitkeep` to explain that the directory is intended for Flexi framework modules, which are now managed as independent Composer packages, and referenced the modular system documentation for further information.