### PR TITLE
refactor: updates namespace to flexi

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -105,7 +105,7 @@ cat > modules/MyModule/composer.json << 'EOF'
   },
   "autoload": {
     "psr-4": {
-      "CubaDevOps\\Flexi\\Modules\\MyModule\\": ""
+      "Flexi\\Modules\\MyModule\\": ""
     }
   }
 }
@@ -145,23 +145,23 @@ should be instantiated, either directly or via factory methods.
 {
   "services": [
     {
-      "name": "CubaDevOps\\Flexi\\Infrastructure\\Classes\\Configuration",
+      "name": "Flexi\\Infrastructure\\Classes\\Configuration",
       "factory": {
-        "class": "CubaDevOps\\Flexi\\Infrastructure\\Factories\\ConfigurationFactory",
+        "class": "Flexi\\Infrastructure\\Factories\\ConfigurationFactory",
         "method": "getInstance",
         "arguments": []
       }
     },
     {
       "name": "session",
-      "alias": "CubaDevOps\\Flexi\\Infrastructure\\Session\\NativeSessionStorage"
+      "alias": "Flexi\\Infrastructure\\Session\\NativeSessionStorage"
     },
     {
       "name": "logger",
       "class": {
         "name": "Flexi\\Contracts\\Classes\\PsrLogger",
         "arguments": [
-          "@CubaDevOps\\Flexi\\Infrastructure\\Persistence\\InFileLogRepository"
+          "@Flexi\\Infrastructure\\Persistence\\InFileLogRepository"
         ]
       }
     },
@@ -195,17 +195,17 @@ handle the request.
       "name": "health",
       "path": "/health",
       "method": "GET",
-      "controller": "CubaDevOps\\Flexi\\Infrastructure\\Controllers\\HealthController",
+      "controller": "Flexi\\Infrastructure\\Controllers\\HealthController",
       "parameters": [],
       "middlewares": [
-        "CubaDevOps\\Flexi\\Infrastructure\\Middlewares\\AuthCheckMiddleware"
+        "Flexi\\Infrastructure\\Middlewares\\AuthCheckMiddleware"
       ]
     },
     {
       "name": "404",
       "path": "/not-found",
       "method": "GET",
-      "controller": "CubaDevOps\\Flexi\\Infrastructure\\Controllers\\NotFoundController"
+      "controller": "Flexi\\Infrastructure\\Controllers\\NotFoundController"
     },
     {
       "glob": "/modules/*/Config/routes.json"
@@ -232,7 +232,7 @@ Events and listeners are defined in the `listeners.json` file. This file maps ev
   {
     "event": "*",
     "listeners": [
-      "CubaDevOps\\Flexi\\Application\\EventListeners\\LoggerEventListener"
+      "Flexi\\Application\\EventListeners\\LoggerEventListener"
     ]
   },
   {
@@ -244,7 +244,7 @@ Events and listeners are defined in the `listeners.json` file. This file maps ev
 __Note:__
 
 - The `event` key can be a specific event name or a wildcard `*` to listen to all events.
-- The listener class should implement the `CubaDevOps\Flexi\Domain\Interfaces\EventListenerInterface` interface.
+- The listener class should implement the `Flexi\Domain\Interfaces\EventListenerInterface` interface.
 
 ### Queries
 
@@ -257,9 +257,9 @@ alias.
 {
   "handlers": [
     {
-      "id": "CubaDevOps\\Flexi\\Domain\\DTO\\EmptyVersionDTO",
+      "id": "Flexi\\Domain\\DTO\\EmptyVersionDTO",
       "cli_alias": "version",
-      "handler": "CubaDevOps\\Flexi\\Application\\UseCase\\Health"
+      "handler": "Flexi\\Application\\UseCase\\Health"
     },
     {
       "glob": "/modules/*/Config/queries.json"
@@ -270,7 +270,7 @@ alias.
 
 __Note:__
 
-- Handlers should implement the `CubaDevOps\Flexi\Domain\Interfaces\HandlerInterface` interface.
+- Handlers should implement the `Flexi\Domain\Interfaces\HandlerInterface` interface.
 
 ### Commands
 
@@ -290,7 +290,7 @@ Commands are defined similarly to queries in the `commands.json` file.
 
 __Note:__
 
-- Handlers should implement the `CubaDevOps\Flexi\Domain\Interfaces\HandlerInterface` interface.
+- Handlers should implement the `Flexi\Domain\Interfaces\HandlerInterface` interface.
 
 ## Usage
 
@@ -301,9 +301,9 @@ The `Router` class is responsible for managing routes and dispatching requests t
 #### Example Usage
 
 ```php
-use CubaDevOps\Flexi\Domain\Classes\Router;
+use Flexi\Domain\Classes\Router;
 use Psr\Http\Message\ServerRequestInterface;
-use CubaDevOps\Flexi\Infrastructure\Factories\ContainerFactory;
+use Flexi\Infrastructure\Factories\ContainerFactory;
 
 /** @var Router $router */
 $router = ContainerFactory::getInstance()->get(Router::class); // or use router alias
@@ -319,11 +319,11 @@ accordingly.
 #### Example
 
 ```php
-use CubaDevOps\Flexi\Domain\Interfaces\EventBusInterface;
-use CubaDevOps\Flexi\Domain\Classes\Event;
-use CubaDevOps\Flexi\Application\UseCase\Health;
-use CubaDevOps\Flexi\Infrastructure\Factories\ContainerFactory;
-use CubaDevOps\Flexi\Infrastructure\Bus\EventBus;
+use Flexi\Domain\Interfaces\EventBusInterface;
+use Flexi\Domain\Classes\Event;
+use Flexi\Application\UseCase\Health;
+use Flexi\Infrastructure\Factories\ContainerFactory;
+use Flexi\Infrastructure\Bus\EventBus;
 
 $eventBus = ContainerFactory::getInstance()->get(EventBus::class);
 $event = new Event('health-check', Health::class, ['from' => $_SERVER['REMOTE_ADDR']);
@@ -337,7 +337,7 @@ Flexi implements the CQRS pattern with separate handling for commands and querie
 #### Command Example
 
 ```php
-use CubaDevOps\Flexi\Infrastructure\Bus\CommandBus;
+use Flexi\Infrastructure\Bus\CommandBus;
 
 // Assume $command is a class that implements the DTOInterface
 $commandBus->execute($command);
@@ -346,7 +346,7 @@ $commandBus->execute($command);
 #### Query Example
 
 ```php
-use CubaDevOps\Flexi\Infrastructure\Bus\QueryBus;
+use Flexi\Infrastructure\Bus\QueryBus;
 
 // Assume $query is a class that implements the DTOInterface
 $result = $queryBus->execute($query);
@@ -354,16 +354,16 @@ $result = $queryBus->execute($query);
 
 ### Controllers and Response
 
-The response is a PSR-7 response object that can be returned from a controller or middleware. Controllers that extend the `CubaDevOps\Flexi\Infrastructure\Classes\HttpHandler` have an easy way to build responses using the `createResponse` method. If you don't extend the `HttpHandler` you can use a factory that implements `Psr\Http\Message\ResponseFactoryInterface` interface to build the response. Flexi uses the `GuzzleHttp\Psr7\HttpFactory` as default factory.
+The response is a PSR-7 response object that can be returned from a controller or middleware. Controllers that extend the `Flexi\Infrastructure\Classes\HttpHandler` have an easy way to build responses using the `createResponse` method. If you don't extend the `HttpHandler` you can use a factory that implements `Psr\Http\Message\ResponseFactoryInterface` interface to build the response. Flexi uses the `GuzzleHttp\Psr7\HttpFactory` as default factory.
 
 The `HttpHandler` abstract class implements a Template Method pattern that automatically manages the middleware chain execution. Controllers only need to implement the `process()` method with their specific business logic, while the framework handles middleware orchestration automatically.
 
 #### Basic Controller Example
 
 ```php
-namespace CubaDevOps\Flexi\Modules\Home\Infrastructure\Controllers;
+namespace Flexi\Modules\Home\Infrastructure\Controllers;
 
-use CubaDevOps\Flexi\Infrastructure\Classes\HttpHandler;
+use Flexi\Infrastructure\Classes\HttpHandler;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -383,11 +383,11 @@ class AuthenticatedController extends HttpHandler
 #### Controller with Dependencies and Business Logic
 
 ```php
-namespace CubaDevOps\Flexi\Infrastructure\Controllers;
+namespace Flexi\Infrastructure\Controllers;
 
-use CubaDevOps\Flexi\Infrastructure\Bus\QueryBus;
-use CubaDevOps\Flexi\Application\Queries\GetVersionQuery;
-use CubaDevOps\Flexi\Infrastructure\Classes\HttpHandler;
+use Flexi\Infrastructure\Bus\QueryBus;
+use Flexi\Application\Queries\GetVersionQuery;
+use Flexi\Infrastructure\Classes\HttpHandler;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -417,10 +417,10 @@ class HealthController extends HttpHandler
 #### Controller with Template Rendering
 
 ```php
-namespace CubaDevOps\Flexi\Infrastructure\Controllers;
+namespace Flexi\Infrastructure\Controllers;
 
-use CubaDevOps\Flexi\Domain\Interfaces\TemplateEngineInterface;
-use CubaDevOps\Flexi\Infrastructure\Classes\HttpHandler;
+use Flexi\Domain\Interfaces\TemplateEngineInterface;
+use Flexi\Infrastructure\Classes\HttpHandler;
 use Flexi\Contracts\Classes\Traits\FileHandlerTrait;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -468,7 +468,7 @@ Middlewares are classes that can be executed before the controller. They can mod
 #### Middleware Implementation Example
 
 ```php
-namespace CubaDevOps\Flexi\Infrastructure\Middlewares;
+namespace Flexi\Infrastructure\Middlewares;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -525,7 +525,7 @@ For more details, see [tests/README.md](tests/README.md).
 ```php
 <?php
 
-namespace CubaDevOps\Flexi\Test\YourNamespace;
+namespace Flexi\Test\YourNamespace;
 
 use PHPUnit\Framework\TestCase;
 

--- a/bin/console
+++ b/bin/console
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 ob_start();
 
-use CubaDevOps\Flexi\Infrastructure\Ui\Cli\ConsoleApplication;
-use CubaDevOps\Flexi\Infrastructure\Ui\Cli\ConsoleOutputFormatter;
+use Flexi\Infrastructure\Ui\Cli\ConsoleApplication;
+use Flexi\Infrastructure\Ui\Cli\ConsoleOutputFormatter;
 
 require_once dirname(__DIR__) . "/vendor/autoload.php";
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "cubadevops/flexi",
+  "name": "flexi/core",
   "description": "The flexible framework that respects standards",
   "version": "2.0.0",
   "time": "2024-06-02",
@@ -38,12 +38,12 @@
   },
   "autoload": {
     "psr-4": {
-      "CubaDevOps\\Flexi\\": "src/"
+      "Flexi\\": "src/"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "CubaDevOps\\Flexi\\Test\\": "tests/"
+      "Flexi\\Test\\": "tests/"
     }
   },
   "scripts": {

--- a/docs/EXTRACTION-SUMMARY.md
+++ b/docs/EXTRACTION-SUMMARY.md
@@ -20,7 +20,7 @@ modules/Logging/
 ```
 
 **Purpose:** Generic file-based log persistence
-- Namespace: `CubaDevOps\Flexi\Modules\Logging\Infrastructure\Persistence`
+- Namespace: `Flexi\Modules\Logging\Infrastructure\Persistence`
 - Service binding: `LogRepositoryInterface` → `InFileLogRepository`
 - Used by: `PsrLogger` in Contracts
 - Extensible: Add `DatabaseLogRepository`, `S3LogRepository`, etc.
@@ -35,7 +35,7 @@ modules/Session/
 ```
 
 **Purpose:** PHP native session storage wrapper
-- Namespace: `CubaDevOps\Flexi\Modules\Session\Infrastructure\Session`
+- Namespace: `Flexi\Modules\Session\Infrastructure\Session`
 - Service binding: `SessionStorageInterface` → `NativeSessionStorage`
 - Alias: `session` (for backwards compatibility)
 - Features: ArrayAccess interface, error handling, PSR-3 logging

--- a/docs/IMPLEMENTATION-SUMMARY.md
+++ b/docs/IMPLEMENTATION-SUMMARY.md
@@ -315,7 +315,7 @@ cat > modules/Payment/composer.json << 'EOF'
   },
   "autoload": {
     "psr-4": {
-      "CubaDevOps\\Flexi\\Modules\\Payment\\": ""
+      "Flexi\\Modules\\Payment\\": ""
     }
   }
 }

--- a/docs/MIGRATION-GUIDE.md
+++ b/docs/MIGRATION-GUIDE.md
@@ -29,7 +29,7 @@ El autoloader de módulos en el composer.json principal ya fue removido:
 
 ```json
 // REMOVIDO:
-"CubaDevOps\\Flexi\\Modules\\": "modules/"
+"Flexi\\Modules\\": "modules/"
 ```
 
 ### 3. Reinstalar Dependencias
@@ -202,7 +202,7 @@ cat > modules/MyNewModule/composer.json << 'EOF'
   },
   "autoload": {
     "psr-4": {
-      "CubaDevOps\\Flexi\\Modules\\MyNewModule\\": ""
+      "Flexi\\Modules\\MyNewModule\\": ""
     }
   },
   "extra": {

--- a/docs/anycriteriai-migration-contracts.md
+++ b/docs/anycriteriai-migration-contracts.md
@@ -50,7 +50,7 @@ contracts/src/Classes/Criteria/
 
 **Module: HealthCheck**
 - File: `modules/HealthCheck/Application/UseCase/Health.php`
-- Old: `use CubaDevOps\Flexi\Domain\Criteria\AnyCriteria;`
+- Old: `use Flexi\Domain\Criteria\AnyCriteria;`
 - New: `use Flexi\Contracts\Classes\Criteria\AnyCriteria;`
 
 ## Verification

--- a/docs/architecture-hexagonal-improvements.md
+++ b/docs/architecture-hexagonal-improvements.md
@@ -193,16 +193,16 @@ Infrastructure/
 
 Si algún módulo externo estaba importando:
 ```php
-use CubaDevOps\Flexi\Infrastructure\Interfaces\ModuleStateManagerInterface;
-use CubaDevOps\Flexi\Infrastructure\Factories\ModuleDetectorInterface;
-use CubaDevOps\Flexi\Application\Commands\NotFoundCommand;
+use Flexi\Infrastructure\Interfaces\ModuleStateManagerInterface;
+use Flexi\Infrastructure\Factories\ModuleDetectorInterface;
+use Flexi\Application\Commands\NotFoundCommand;
 ```
 
 Debe actualizar a:
 ```php
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleStateManagerInterface;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleDetectorInterface;
-use CubaDevOps\Flexi\Domain\Commands\NotFoundCommand;
+use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
+use Flexi\Domain\Interfaces\ModuleDetectorInterface;
+use Flexi\Domain\Commands\NotFoundCommand;
 ```
 
 ## Conclusión

--- a/docs/architecture-reorganization.md
+++ b/docs/architecture-reorganization.md
@@ -87,19 +87,19 @@ All imports were updated in the following files:
 {
   "handlers": [
     {
-      "id": "CubaDevOps\\Flexi\\Application\\Queries\\GetVersionQuery",
+      "id": "Flexi\\Application\\Queries\\GetVersionQuery",
       "cli_alias": "version",
-      "handler": "CubaDevOps\\Flexi\\Application\\UseCase\\Health"
+      "handler": "Flexi\\Application\\UseCase\\Health"
     },
     {
-      "id": "CubaDevOps\\Flexi\\Application\\Queries\\ListQueriesQuery",
+      "id": "Flexi\\Application\\Queries\\ListQueriesQuery",
       "cli_alias": "query:list",
-      "handler": "CubaDevOps\\Flexi\\Application\\UseCase\\ListQueries"
+      "handler": "Flexi\\Application\\UseCase\\ListQueries"
     },
     {
-      "id": "CubaDevOps\\Flexi\\Application\\Commands\\ListCommandsCommand",
+      "id": "Flexi\\Application\\Commands\\ListCommandsCommand",
       "cli_alias": "command:list",
-      "handler": "CubaDevOps\\Flexi\\Application\\UseCase\\ListCommands"
+      "handler": "Flexi\\Application\\UseCase\\ListCommands"
     }
   ]
 }

--- a/docs/cache-module-extraction-complete.md
+++ b/docs/cache-module-extraction-complete.md
@@ -75,9 +75,9 @@ Todos los componentes ahora usan el namespace `Modules\Cache\`:
 
 ```php
 // Antes
-namespace CubaDevOps\Flexi\Infrastructure\Cache;
-namespace CubaDevOps\Flexi\Infrastructure\Factories;
-namespace CubaDevOps\Flexi\Domain\Exceptions;
+namespace Flexi\Infrastructure\Cache;
+namespace Flexi\Infrastructure\Factories;
+namespace Flexi\Domain\Exceptions;
 
 // Después
 namespace Modules\Cache\Infrastructure\Cache;
@@ -92,7 +92,7 @@ namespace Modules\Cache\Domain\Exceptions;
 {
   "name": "Flexi\\Contracts\\Interfaces\\CacheInterface",
   "factory": {
-    "class": "CubaDevOps\\Flexi\\Infrastructure\\Factories\\CacheFactory",
+    "class": "Flexi\\Infrastructure\\Factories\\CacheFactory",
     "method": "createDefault",
     "arguments": ["@Flexi\\Contracts\\Interfaces\\ConfigurationInterface"]
   }
@@ -170,7 +170,7 @@ Se actualizó `tests/Domain/Utils/ClassFactoryTest.php`:
 
 ```php
 // Antes
-use CubaDevOps\Flexi\Infrastructure\Factories\CacheFactory;
+use Flexi\Infrastructure\Factories\CacheFactory;
 
 // Después
 use Modules\Cache\Infrastructure\Factories\CacheFactory;
@@ -183,8 +183,8 @@ Se actualizó `composer.json` para incluir el namespace `Modules\`:
 ```json
 "autoload": {
   "psr-4": {
-    "CubaDevOps\\Flexi\\": "src/",
-    "CubaDevOps\\Flexi\\Modules\\": "modules/",
+    "Flexi\\": "src/",
+    "Flexi\\Modules\\": "modules/",
     "Modules\\": "modules/"  // ← Nuevo
   }
 }
@@ -242,8 +242,8 @@ Si tienes código que dependía directamente de las clases del core:
 
 ### ❌ Antes (acoplado al core)
 ```php
-use CubaDevOps\Flexi\Infrastructure\Cache\FileCache;
-use CubaDevOps\Flexi\Infrastructure\Factories\CacheFactory;
+use Flexi\Infrastructure\Cache\FileCache;
+use Flexi\Infrastructure\Factories\CacheFactory;
 
 $cache = new FileCache('/path/to/cache');
 ```

--- a/docs/cleanup-old-utilities.md
+++ b/docs/cleanup-old-utilities.md
@@ -27,11 +27,11 @@ From `src/Infrastructure/Utils/`:
 - Changed to: `Contracts\Classes\Traits\FileHandlerTrait`
 
 **2. Test Fixtures (`tests/TestData/TestDoubles/FileHandler.php`)**
-- Old: `use CubaDevOps\Flexi\Infrastructure\Utils\FileHandlerTrait;`
+- Old: `use Flexi\Infrastructure\Utils\FileHandlerTrait;`
 - New: `use Flexi\Contracts\Classes\Traits\FileHandlerTrait;`
 
 **3. Module Code (`modules/HealthCheck/Infrastructure/Persistence/VersionRepository.php`)**
-- Old: `use CubaDevOps\Flexi\Infrastructure\Utils\JsonFileReader;`
+- Old: `use Flexi\Infrastructure\Utils\JsonFileReader;`
 - New: `use Flexi\Contracts\Classes\Traits\JsonFileReader;`
 
 ## Verification Steps

--- a/docs/console-error-formatting-example.md
+++ b/docs/console-error-formatting-example.md
@@ -47,11 +47,11 @@ Location:
   Line: 42
 
 Stack Trace:
-  #0 CubaDevOps\Flexi\Infrastructure\Ui\Cli\CommandHandler->handle
+  #0 Flexi\Infrastructure\Ui\Cli\CommandHandler->handle
       ./src/Infrastructure/Ui/Cli/CommandHandler.php:25
-  #1 CubaDevOps\Flexi\Infrastructure\Ui\Cli\ConsoleApplication::handle
+  #1 Flexi\Infrastructure\Ui\Cli\ConsoleApplication::handle
       ./src/Infrastructure/Ui/Cli/ConsoleApplication.php:68
-  #2 CubaDevOps\Flexi\Infrastructure\Ui\Cli\ConsoleApplication::run
+  #2 Flexi\Infrastructure\Ui\Cli\ConsoleApplication::run
       ./src/Infrastructure/Ui/Cli/ConsoleApplication.php:41
   ... más frames
 

--- a/docs/contracts-simple-migration.md
+++ b/docs/contracts-simple-migration.md
@@ -28,8 +28,8 @@ composer update  # Para instalar el paquete contracts
 #### Antes (actual):
 ```php
 // modules/Home/Application/RenderHome.php
-use CubaDevOps\Flexi\Domain\Interfaces\DTOInterface;
-use CubaDevOps\Flexi\Domain\Interfaces\HandlerInterface;
+use Flexi\Domain\Interfaces\DTOInterface;
+use Flexi\Domain\Interfaces\HandlerInterface;
 
 class RenderHome implements HandlerInterface
 {
@@ -62,9 +62,9 @@ class RenderHome implements HandlerInterface
 {
   "services": [
     {
-      "name": "CubaDevOps\\Flexi\\Modules\\Home\\Application\\RenderHome",
+      "name": "Flexi\\Modules\\Home\\Application\\RenderHome",
       "class": {
-        "name": "CubaDevOps\\Flexi\\Modules\\Home\\Application\\RenderHome",
+        "name": "Flexi\\Modules\\Home\\Application\\RenderHome",
         "arguments": ["@template_engine"]
       }
     }
@@ -77,8 +77,8 @@ class RenderHome implements HandlerInterface
 {
   "handlers": [
     {
-      "id": "CubaDevOps\\Flexi\\Modules\\Home\\Domain\\HomePageDTO",
-      "handler": "CubaDevOps\\Flexi\\Modules\\Home\\Application\\RenderHome"
+      "id": "Flexi\\Modules\\Home\\Domain\\HomePageDTO",
+      "handler": "Flexi\\Modules\\Home\\Application\\RenderHome"
     }
   ]
 }

--- a/docs/core-module-dependency-removal.md
+++ b/docs/core-module-dependency-removal.md
@@ -110,7 +110,7 @@ class RouteNotFoundListener implements EventListenerInterface
   "listeners": [
     {
       "event": "core.routeNotFound",
-      "handler": "CubaDevOps\\Flexi\\Modules\\ErrorHandling\\Infrastructure\\Listeners\\RouteNotFoundListener"
+      "handler": "Flexi\\Modules\\ErrorHandling\\Infrastructure\\Listeners\\RouteNotFoundListener"
     }
   ]
 }
@@ -121,9 +121,9 @@ class RouteNotFoundListener implements EventListenerInterface
 {
   "services": [
     {
-      "name": "CubaDevOps\\Flexi\\Modules\\ErrorHandling\\Infrastructure\\Listeners\\RouteNotFoundListener",
+      "name": "Flexi\\Modules\\ErrorHandling\\Infrastructure\\Listeners\\RouteNotFoundListener",
       "class": {
-        "name": "CubaDevOps\\Flexi\\Modules\\ErrorHandling\\Infrastructure\\Listeners\\RouteNotFoundListener",
+        "name": "Flexi\\Modules\\ErrorHandling\\Infrastructure\\Listeners\\RouteNotFoundListener",
         "arguments": [
           "@session",
           "@Psr\\Http\\Message\\ResponseFactoryInterface"

--- a/docs/core-refactor-architecture-proposal.md
+++ b/docs/core-refactor-architecture-proposal.md
@@ -385,7 +385,7 @@ modules/Auth/
 Si `EventListener.php` se mueve a Contracts:
 ```php
 // Antes
-use CubaDevOps\Flexi\Domain\Events\EventListener;
+use Flexi\Domain\Events\EventListener;
 
 // Después
 use Flexi\Contracts\Classes\EventListener;
@@ -402,10 +402,10 @@ use Flexi\Contracts\Classes\EventListener;
 Si ValueObjects de DI se mueven:
 ```php
 // Antes
-use CubaDevOps\Flexi\Domain\ValueObjects\Operator;
+use Flexi\Domain\ValueObjects\Operator;
 
 // Después
-use CubaDevOps\Flexi\Infrastructure\DependencyInjection\ValueObjects\Operator;
+use Flexi\Infrastructure\DependencyInjection\ValueObjects\Operator;
 ```
 
 **Archivos a actualizar:**

--- a/docs/core-refactor-visualization.md
+++ b/docs/core-refactor-visualization.md
@@ -248,7 +248,7 @@ Mover Traits de Utils
 Mover ValueObjects de DI
 ├─ src/Infrastructure/DependencyInjection/ServicesDefinitionParser.php
 │  ├─ usa: ServiceType
-│  └─ update: use CubaDevOps\Flexi\Infrastructure\DependencyInjection\ValueObjects\ServiceType;
+│  └─ update: use Flexi\Infrastructure\DependencyInjection\ValueObjects\ServiceType;
 ├─ Posiblemente: Container, Service, ServiceClassDefinition
 └─ Necesita: verificar que no hay imports en módulos
 
@@ -305,9 +305,9 @@ podman exec flexi vendor/bin/phpunit tests/ -v
 
 ```bash
 # Buscar imports antiguos
-grep -r "use CubaDevOps\\Flexi\\Domain\\ValueObjects\\Operator" src/
-grep -r "use CubaDevOps\\Flexi\\Domain\\Events\\EventListener" src/
-grep -r "use CubaDevOps\\Flexi\\Infrastructure\\Utils\\.*Trait" src/
+grep -r "use Flexi\\Domain\\ValueObjects\\Operator" src/
+grep -r "use Flexi\\Domain\\Events\\EventListener" src/
+grep -r "use Flexi\\Infrastructure\\Utils\\.*Trait" src/
 ```
 
 ---

--- a/docs/dependency-direction-fix-modules-provider.md
+++ b/docs/dependency-direction-fix-modules-provider.md
@@ -164,7 +164,7 @@ class EventBus
 }
 
 // DESPUÉS
-use CubaDevOps\Flexi\Infrastructure\Classes\InstalledModulesFilter;
+use Flexi\Infrastructure\Classes\InstalledModulesFilter;
 
 class EventBus
 {
@@ -193,7 +193,7 @@ class EventBus
 Los módulos pueden usar `InstalledModulesProviderTrait` para verificar dependencias:
 
 ```php
-namespace CubaDevOps\Flexi\Modules\MyModule;
+namespace Flexi\Modules\MyModule;
 
 use Flexi\Contracts\Classes\Traits\InstalledModulesProviderTrait;
 

--- a/docs/domain-infrastructure-separation.md
+++ b/docs/domain-infrastructure-separation.md
@@ -8,9 +8,9 @@ In the previous implementation, the `Route` class (domain) had the responsibilit
 
 ```php
 // src/Domain/Classes/Route.php
-namespace CubaDevOps\Flexi\Domain\Classes;
+namespace Flexi\Domain\Classes;
 
-use CubaDevOps\Flexi\Infrastructure\Classes\HttpHandler; // ❌ Domain depends on Infrastructure
+use Flexi\Infrastructure\Classes\HttpHandler; // ❌ Domain depends on Infrastructure
 use Psr\Container\ContainerInterface;
 
 class Route
@@ -54,7 +54,7 @@ class Route
 
 ```php
 // src/Domain/Classes/Route.php
-namespace CubaDevOps\Flexi\Domain\Classes;
+namespace Flexi\Domain\Classes;
 
 class Route // ✅ No infrastructure dependencies
 {

--- a/docs/generic-classes-migration-contracts.md
+++ b/docs/generic-classes-migration-contracts.md
@@ -233,7 +233,7 @@ use Flexi\Contracts\ValueObjects\Operator;
 use Flexi\Contracts\ValueObjects\Order;
 
 // Sin necesidad de importar del core!
-// No más: use CubaDevOps\Flexi\Infrastructure\Utils\...
+// No más: use Flexi\Infrastructure\Utils\...
 ```
 
 ---

--- a/docs/httphandler-dependency-injection-pattern.md
+++ b/docs/httphandler-dependency-injection-pattern.md
@@ -83,7 +83,7 @@ abstract class HttpHandler implements RequestHandlerInterface
 All controllers extending `HttpHandler` must pass the dependency to parent constructor:
 
 ```php
-namespace CubaDevOps\Flexi\Modules\Home\Infrastructure\Controllers;
+namespace Flexi\Modules\Home\Infrastructure\Controllers;
 
 use Flexi\Contracts\Classes\HttpHandler;
 use Psr\Http\Message\ResponseFactoryInterface;
@@ -260,8 +260,8 @@ $controller = new MyNewController($factory);
 Use DummyResponseFactory for pure PSR testing without external dependencies:
 
 ```php
-use CubaDevOps\Flexi\Test\TestData\TestDoubles\DummyResponseFactory;
-use CubaDevOps\Flexi\Test\TestData\TestDoubles\TestHttpHandler;
+use Flexi\Test\TestData\TestDoubles\DummyResponseFactory;
+use Flexi\Test\TestData\TestDoubles\TestHttpHandler;
 
 $factory = new DummyResponseFactory();
 $handler = new TestHttpHandler($factory);

--- a/docs/middleware-extraction-analysis.md
+++ b/docs/middleware-extraction-analysis.md
@@ -341,7 +341,7 @@ modules/Auth/
 ### Phase 1: Extract HttpHandler to Contracts
 
 1. Move `src/Infrastructure/Classes/HttpHandler.php` to `contracts/src/Classes/HttpHandler.php`
-2. Update namespace: `CubaDevOps\Flexi\Infrastructure\Classes` → `Flexi\Contracts\Classes`
+2. Update namespace: `Flexi\Infrastructure\Classes` → `Flexi\Contracts\Classes`
 3. Update imports in all controllers/handlers in core and modules
 
 ### Phase 2: Create modules/Auth
@@ -439,21 +439,21 @@ Module `modules/Auth/Config/services.json` will define:
     {
       "name": "Flexi\\Contracts\\Interfaces\\SecretProviderInterface",
       "class": {
-        "name": "CubaDevOps\\Flexi\\Modules\\Auth\\Infrastructure\\Adapters\\ConfigurationSecretProvider",
-        "arguments": ["@CubaDevOps\\Flexi\\Infrastructure\\Classes\\Configuration"]
+        "name": "Flexi\\Modules\\Auth\\Infrastructure\\Adapters\\ConfigurationSecretProvider",
+        "arguments": ["@Flexi\\Infrastructure\\Classes\\Configuration"]
       }
     },
     {
       "name": "auth_check_middleware",
       "class": {
-        "name": "CubaDevOps\\Flexi\\Modules\\Auth\\Infrastructure\\Middlewares\\AuthCheckMiddleware",
+        "name": "Flexi\\Modules\\Auth\\Infrastructure\\Middlewares\\AuthCheckMiddleware",
         "arguments": ["@Flexi\\Contracts\\Interfaces\\SessionStorageInterface", "@Psr\\Http\\Message\\ResponseFactoryInterface"]
       }
     },
     {
       "name": "jwt_auth_middleware",
       "class": {
-        "name": "CubaDevOps\\Flexi\\Modules\\Auth\\Infrastructure\\Middlewares\\JWTAuthMiddleware",
+        "name": "Flexi\\Modules\\Auth\\Infrastructure\\Middlewares\\JWTAuthMiddleware",
         "arguments": ["@Flexi\\Contracts\\Interfaces\\SecretProviderInterface", "@Psr\\Http\\Message\\ResponseFactoryInterface"]
       }
     }

--- a/docs/middleware-extraction-complete.md
+++ b/docs/middleware-extraction-complete.md
@@ -22,7 +22,7 @@ contracts/src/Classes/HttpHandler.php
 ```
 
 **Cambios:**
-- Namespace: `CubaDevOps\Flexi\Infrastructure\Classes` → `Flexi\Contracts\Classes`
+- Namespace: `Flexi\Infrastructure\Classes` → `Flexi\Contracts\Classes`
 - Actualizado import en Router.php
 - Actualizado import en TestHttpHandler.php
 - Eliminado original del core
@@ -83,17 +83,17 @@ $key = $this->secret_provider->getSecret();  // ✅ 95% genérica
 {
   "name": "Flexi\\Contracts\\Interfaces\\SecretProviderInterface",
   "class": {
-    "name": "CubaDevOps\\Flexi\\Modules\\Auth\\Infrastructure\\Adapters\\ConfigurationSecretProvider",
-    "arguments": ["@CubaDevOps\\Flexi\\Infrastructure\\Classes\\Configuration"]
+    "name": "Flexi\\Modules\\Auth\\Infrastructure\\Adapters\\ConfigurationSecretProvider",
+    "arguments": ["@Flexi\\Infrastructure\\Classes\\Configuration"]
   }
 },
 {
   "name": "auth_check_middleware",
-  "class": { "name": "CubaDevOps\\Flexi\\Modules\\Auth\\Infrastructure\\Middlewares\\AuthCheckMiddleware", ... }
+  "class": { "name": "Flexi\\Modules\\Auth\\Infrastructure\\Middlewares\\AuthCheckMiddleware", ... }
 },
 {
   "name": "jwt_auth_middleware",
-  "class": { "name": "CubaDevOps\\Flexi\\Modules\\Auth\\Infrastructure\\Middlewares\\JWTAuthMiddleware", ... }
+  "class": { "name": "Flexi\\Modules\\Auth\\Infrastructure\\Middlewares\\JWTAuthMiddleware", ... }
 }
 ```
 
@@ -259,7 +259,7 @@ class OAuth2Middleware implements MiddlewareInterface { ... }
 { "name": "oauth2_middleware", "class": { ... } }
 
 // 3. Usar en rutas
-{ "middlewares": ["CubaDevOps\\Flexi\\Modules\\Auth\\Infrastructure\\Middlewares\\OAuth2Middleware"] }
+{ "middlewares": ["Flexi\\Modules\\Auth\\Infrastructure\\Middlewares\\OAuth2Middleware"] }
 ```
 
 ### Cambiar fuente de secretos

--- a/docs/middleware-management-improvements.md
+++ b/docs/middleware-management-improvements.md
@@ -99,7 +99,7 @@ Implement the Template Method pattern in `HttpHandler` to automatically manage t
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Classes;
+namespace Flexi\Infrastructure\Classes;
 
 use GuzzleHttp\Psr7\HttpFactory;
 use Psr\Http\Message\RequestFactoryInterface;

--- a/docs/modular-system-automatic.md
+++ b/docs/modular-system-automatic.md
@@ -250,7 +250,7 @@ cat > modules/Payment/composer.json << 'EOF'
   },
   "autoload": {
     "psr-4": {
-      "CubaDevOps\\Flexi\\Modules\\Payment\\": ""
+      "Flexi\\Modules\\Payment\\": ""
     }
   },
   "extra": {

--- a/docs/modular-system-with-composer.md
+++ b/docs/modular-system-with-composer.md
@@ -66,7 +66,7 @@ Cada módulo tiene su propio `composer.json` con la siguiente estructura:
   },
   "autoload": {
     "psr-4": {
-      "CubaDevOps\\Flexi\\Modules\\{Nombre}\\": ""
+      "Flexi\\Modules\\{Nombre}\\": ""
     }
   },
   "extra": {
@@ -297,7 +297,7 @@ mkdir -p modules/MyModule/{Domain,Infrastructure,Config}
   },
   "autoload": {
     "psr-4": {
-      "CubaDevOps\\Flexi\\Modules\\MyModule\\": ""
+      "Flexi\\Modules\\MyModule\\": ""
     }
   }
 }

--- a/docs/module-environment-management-implementation-summary.md
+++ b/docs/module-environment-management-implementation-summary.md
@@ -153,13 +153,13 @@ AUTH_SESSION_COOKIE_SECURE=false
 ### Servicios Agregados (`services.json`)
 ```json
 {
-  "name": "CubaDevOps\\Flexi\\Infrastructure\\Interfaces\\ModuleEnvironmentManagerInterface",
-  "alias": "CubaDevOps\\Flexi\\Infrastructure\\Classes\\ModuleEnvironmentManager"
+  "name": "Flexi\\Infrastructure\\Interfaces\\ModuleEnvironmentManagerInterface",
+  "alias": "Flexi\\Infrastructure\\Classes\\ModuleEnvironmentManager"
 },
 {
-  "name": "CubaDevOps\\Flexi\\Infrastructure\\Classes\\ModuleEnvironmentManager",
+  "name": "Flexi\\Infrastructure\\Classes\\ModuleEnvironmentManager",
   "class": {
-    "name": "CubaDevOps\\Flexi\\Infrastructure\\Classes\\ModuleEnvironmentManager",
+    "name": "Flexi\\Infrastructure\\Classes\\ModuleEnvironmentManager",
     "arguments": ["@Flexi\\Contracts\\Interfaces\\ConfigurationInterface"]
   }
 }
@@ -168,9 +168,9 @@ AUTH_SESSION_COOKIE_SECURE=false
 ### Comandos Agregados (`commands.json`)
 ```json
 {
-  "id": "CubaDevOps\\Flexi\\Application\\Commands\\UpdateModuleEnvironmentCommand",
+  "id": "Flexi\\Application\\Commands\\UpdateModuleEnvironmentCommand",
   "cli_alias": "modules:env-update",
-  "handler": "CubaDevOps\\Flexi\\Application\\UseCase\\UpdateModuleEnvironment"
+  "handler": "Flexi\\Application\\UseCase\\UpdateModuleEnvironment"
 }
 ```
 

--- a/docs/persistence-session-extraction-analysis.md
+++ b/docs/persistence-session-extraction-analysis.md
@@ -58,9 +58,9 @@ Interface: contracts/src/Interfaces/LogRepositoryInterface.php
 ```php
 // In src/Config/services.json
 {
-  "name": "CubaDevOps\\Flexi\\Infrastructure\\Persistence\\InFileLogRepository",
+  "name": "Flexi\\Infrastructure\\Persistence\\InFileLogRepository",
   "class": {
-    "name": "CubaDevOps\\Flexi\\Infrastructure\\Persistence\\InFileLogRepository",
+    "name": "Flexi\\Infrastructure\\Persistence\\InFileLogRepository",
     "arguments": [
       "ENV.log_file_path",
       "ENV.log_format"
@@ -117,9 +117,9 @@ Interface: contracts/src/Interfaces/SessionStorageInterface.php
 ```php
 // In src/Config/services.json
 {
-  "name": "CubaDevOps\\Flexi\\Infrastructure\\Session\\NativeSessionStorage",
+  "name": "Flexi\\Infrastructure\\Session\\NativeSessionStorage",
   "class": {
-    "name": "CubaDevOps\\Flexi\\Infrastructure\\Session\\NativeSessionStorage",
+    "name": "Flexi\\Infrastructure\\Session\\NativeSessionStorage",
     "arguments": [
       "@logger",
       {
@@ -269,7 +269,7 @@ modules/Logging/
     {
       "name": "Flexi\\Contracts\\Interfaces\\LogRepositoryInterface",
       "class": {
-        "name": "CubaDevOps\\Flexi\\Modules\\Logging\\Infrastructure\\Persistence\\InFileLogRepository",
+        "name": "Flexi\\Modules\\Logging\\Infrastructure\\Persistence\\InFileLogRepository",
         "arguments": ["ENV.log_file_path", "ENV.log_format"]
       }
     }
@@ -296,7 +296,7 @@ modules/Session/
     {
       "name": "Flexi\\Contracts\\Interfaces\\SessionStorageInterface",
       "class": {
-        "name": "CubaDevOps\\Flexi\\Modules\\Session\\Infrastructure\\Session\\NativeSessionStorage",
+        "name": "Flexi\\Modules\\Session\\Infrastructure\\Session\\NativeSessionStorage",
         "arguments": [
           "@logger",
           { /* session options */ }

--- a/docs/persistence-session-extraction-complete.md
+++ b/docs/persistence-session-extraction-complete.md
@@ -21,11 +21,11 @@ Successfully extracted `InFileLogRepository` and `NativeSessionStorage` from cor
 modules/Logging/
 ├── Infrastructure/Persistence/
 │   └── InFileLogRepository.php
-│       └── Namespace: CubaDevOps\Flexi\Modules\Logging\Infrastructure\Persistence
+│       └── Namespace: Flexi\Modules\Logging\Infrastructure\Persistence
 ├── Config/services.json
 ├── tests/Infrastructure/Persistence/
 │   └── InFileLogRepositoryTest.php
-│       └── Namespace: CubaDevOps\Flexi\Modules\Logging\Test\Infrastructure\Persistence
+│       └── Namespace: Flexi\Modules\Logging\Test\Infrastructure\Persistence
 └── README.md (future)
 ```
 
@@ -41,7 +41,7 @@ modules/Logging/
 {
   "name": "Flexi\\Contracts\\Interfaces\\LogRepositoryInterface",
   "class": {
-    "name": "CubaDevOps\\Flexi\\Modules\\Logging\\Infrastructure\\Persistence\\InFileLogRepository",
+    "name": "Flexi\\Modules\\Logging\\Infrastructure\\Persistence\\InFileLogRepository",
     "arguments": ["ENV.log_file_path", "ENV.log_format"]
   }
 }
@@ -56,11 +56,11 @@ modules/Logging/
 modules/Session/
 ├── Infrastructure/Session/
 │   └── NativeSessionStorage.php
-│       └── Namespace: CubaDevOps\Flexi\Modules\Session\Infrastructure\Session
+│       └── Namespace: Flexi\Modules\Session\Infrastructure\Session
 ├── Config/services.json
 ├── tests/Infrastructure/Session/
 │   └── NativeSessionStorageTest.php
-│       └── Namespace: CubaDevOps\Flexi\Modules\Session\Test\Infrastructure\Session
+│       └── Namespace: Flexi\Modules\Session\Test\Infrastructure\Session
 └── README.md (future)
 ```
 
@@ -77,7 +77,7 @@ modules/Session/
 {
   "name": "Flexi\\Contracts\\Interfaces\\SessionStorageInterface",
   "class": {
-    "name": "CubaDevOps\\Flexi\\Modules\\Session\\Infrastructure\\Session\\NativeSessionStorage",
+    "name": "Flexi\\Modules\\Session\\Infrastructure\\Session\\NativeSessionStorage",
     "arguments": [
       "@logger",
       {
@@ -119,16 +119,16 @@ mkdir -p modules/Session/tests/Infrastructure/Session
 
 ### Phase 2: Moved Source Code with Namespace Updates
 - Copied `InFileLogRepository.php` → `modules/Logging/Infrastructure/Persistence/`
-  - Updated namespace: `CubaDevOps\Flexi\Infrastructure\Persistence` → `CubaDevOps\Flexi\Modules\Logging\Infrastructure\Persistence`
+  - Updated namespace: `Flexi\Infrastructure\Persistence` → `Flexi\Modules\Logging\Infrastructure\Persistence`
 - Copied `NativeSessionStorage.php` → `modules/Session/Infrastructure/Session/`
-  - Updated namespace: `CubaDevOps\Flexi\Infrastructure\Session` → `CubaDevOps\Flexi\Modules\Session\Infrastructure\Session`
+  - Updated namespace: `Flexi\Infrastructure\Session` → `Flexi\Modules\Session\Infrastructure\Session`
 
 ### Phase 3: Moved Tests with Namespace Updates
 - Moved `InFileLogRepositoryTest.php` → `modules/Logging/tests/Infrastructure/Persistence/`
-  - Updated namespace: `CubaDevOps\Flexi\Test\Infrastructure\Persistence` → `CubaDevOps\Flexi\Modules\Logging\Test\Infrastructure\Persistence`
+  - Updated namespace: `Flexi\Test\Infrastructure\Persistence` → `Flexi\Modules\Logging\Test\Infrastructure\Persistence`
   - Updated class reference: `InFileLogRepository` → full namespace path
 - Moved `NativeSessionStorageTest.php` → `modules/Session/tests/Infrastructure/Session/`
-  - Updated namespace: `CubaDevOps\Flexi\Test\Infrastructure\Session` → `CubaDevOps\Flexi\Modules\Session\Test\Infrastructure\Session`
+  - Updated namespace: `Flexi\Test\Infrastructure\Session` → `Flexi\Modules\Session\Test\Infrastructure\Session`
   - Updated class reference: `NativeSessionStorage` → full namespace path
 
 ### Phase 4: Created Module Service Definitions
@@ -168,9 +168,9 @@ rm tests/Infrastructure/Session/NativeSessionStorageTest.php
 ### Before Extraction
 ```
 src/Config/services.json
-├── CubaDevOps\Flexi\Infrastructure\Session\NativeSessionStorage
-├── CubaDevOps\Flexi\Infrastructure\Persistence\InFileLogRepository
-└── logger → @CubaDevOps\Flexi\Infrastructure\Persistence\InFileLogRepository
+├── Flexi\Infrastructure\Session\NativeSessionStorage
+├── Flexi\Infrastructure\Persistence\InFileLogRepository
+└── logger → @Flexi\Infrastructure\Persistence\InFileLogRepository
 
 Core Infrastructure
 ├── Session/ → NativeSessionStorage
@@ -274,7 +274,7 @@ Switch implementations by changing `services.json`:
 {
   "name": "Flexi\\Contracts\\Interfaces\\LogRepositoryInterface",
   "class": {
-    "name": "CubaDevOps\\Flexi\\Modules\\Logging\\Infrastructure\\Persistence\\DatabaseLogRepository"
+    "name": "Flexi\\Modules\\Logging\\Infrastructure\\Persistence\\DatabaseLogRepository"
   }
 }
 ```

--- a/docs/psrlogger-migration-contracts.md
+++ b/docs/psrlogger-migration-contracts.md
@@ -55,7 +55,7 @@ Created new file: `contracts/src/Classes/PsrLogger.php`
 **a) Dependency Injection (src/Config/services.json)**
 ```json
 BEFORE:
-"name": "CubaDevOps\\Flexi\\Infrastructure\\Classes\\PsrLogger"
+"name": "Flexi\\Infrastructure\\Classes\\PsrLogger"
 
 AFTER:
 "name": "Flexi\\Contracts\\Classes\\PsrLogger"

--- a/docs/refactor-implementation-guide.md
+++ b/docs/refactor-implementation-guide.md
@@ -40,7 +40,7 @@ src/Infrastructure/Utils/JsonFileReader.php             → contracts/src/Classe
 
 ```php
 // ANTES:
-namespace CubaDevOps\Flexi\Infrastructure\Utils;
+namespace Flexi\Infrastructure\Utils;
 
 // DESPUÉS:
 namespace Flexi\Contracts\Classes\Traits;
@@ -57,8 +57,8 @@ namespace Flexi\Contracts\Classes\Traits;
 
 ```php
 // ANTES:
-use CubaDevOps\Flexi\Infrastructure\Utils\GlobFileReader;
-use CubaDevOps\Flexi\Infrastructure\Utils\JsonFileReader;
+use Flexi\Infrastructure\Utils\GlobFileReader;
+use Flexi\Infrastructure\Utils\JsonFileReader;
 
 // DESPUÉS:
 use Flexi\Contracts\Classes\Traits\GlobFileReader;
@@ -102,7 +102,7 @@ git commit -m "refactor: move utility traits to contracts"
 
 ```php
 // ANTES:
-namespace CubaDevOps\Flexi\Domain\Events;
+namespace Flexi\Domain\Events;
 
 // DESPUÉS:
 namespace Flexi\Contracts\Classes;
@@ -117,7 +117,7 @@ namespace Flexi\Contracts\Classes;
 
 ```php
 // ANTES:
-use CubaDevOps\Flexi\Domain\Events\EventListener;
+use Flexi\Domain\Events\EventListener;
 
 // DESPUÉS:
 use Flexi\Contracts\Classes\EventListener;
@@ -173,10 +173,10 @@ mv src/Domain/ValueObjects/ServiceType.php \
 
 ```php
 // ANTES:
-namespace CubaDevOps\Flexi\Domain\ValueObjects;
+namespace Flexi\Domain\ValueObjects;
 
 // DESPUÉS:
-namespace CubaDevOps\Flexi\Infrastructure\DependencyInjection\ValueObjects;
+namespace Flexi\Infrastructure\DependencyInjection\ValueObjects;
 ```
 
 ### Paso 3.4: Buscar y actualizar todos los imports
@@ -192,14 +192,14 @@ grep -r "use CubaDevOps\\\\Flexi\\\\Domain\\\\ValueObjects\\\\ServiceType" /User
 
 ```php
 // ANTES:
-use CubaDevOps\Flexi\Domain\ValueObjects\Operator;
-use CubaDevOps\Flexi\Domain\ValueObjects\Order;
-use CubaDevOps\Flexi\Domain\ValueObjects\ServiceType;
+use Flexi\Domain\ValueObjects\Operator;
+use Flexi\Domain\ValueObjects\Order;
+use Flexi\Domain\ValueObjects\ServiceType;
 
 // DESPUÉS:
-use CubaDevOps\Flexi\Infrastructure\DependencyInjection\ValueObjects\Operator;
-use CubaDevOps\Flexi\Infrastructure\DependencyInjection\ValueObjects\Order;
-use CubaDevOps\Flexi\Infrastructure\DependencyInjection\ValueObjects\ServiceType;
+use Flexi\Infrastructure\DependencyInjection\ValueObjects\Operator;
+use Flexi\Infrastructure\DependencyInjection\ValueObjects\Order;
+use Flexi\Infrastructure\DependencyInjection\ValueObjects\ServiceType;
 ```
 
 ### Paso 3.5: Actualizar composer autoload
@@ -253,10 +253,10 @@ cp src/Infrastructure/Middlewares/JWTAuthMiddleware.php \
 
 ```php
 // ANTES (AuthCheckMiddleware.php):
-namespace CubaDevOps\Flexi\Infrastructure\Middlewares;
+namespace Flexi\Infrastructure\Middlewares;
 
 // DESPUÉS:
-namespace CubaDevOps\Flexi\Modules\Auth\Infrastructure\Middlewares;
+namespace Flexi\Modules\Auth\Infrastructure\Middlewares;
 ```
 
 ### Paso 4.4: Crear composer.json para el módulo (opcional)
@@ -267,7 +267,7 @@ namespace CubaDevOps\Flexi\Modules\Auth\Infrastructure\Middlewares;
   "description": "Authentication module for Flexi Framework",
   "autoload": {
     "psr-4": {
-      "CubaDevOps\\Flexi\\Modules\\Auth\\": "."
+      "Flexi\\Modules\\Auth\\": "."
     }
   }
 }
@@ -285,10 +285,10 @@ grep -r "AuthCheckMiddleware" /Users/cbatista8a/Sites/flexi/
 
 ```php
 // ANTES:
-use CubaDevOps\Flexi\Infrastructure\Middlewares\AuthCheckMiddleware;
+use Flexi\Infrastructure\Middlewares\AuthCheckMiddleware;
 
 // DESPUÉS:
-use CubaDevOps\Flexi\Modules\Auth\Infrastructure\Middlewares\AuthCheckMiddleware;
+use Flexi\Modules\Auth\Infrastructure\Middlewares\AuthCheckMiddleware;
 ```
 
 ### Paso 4.6: Actualizar composer autoload

--- a/docs/template-rendering-flow.md
+++ b/docs/template-rendering-flow.md
@@ -188,16 +188,16 @@ In `src/Config/services.json`:
 {
   "name": "html_render",
   "class": {
-    "name": "CubaDevOps\\Flexi\\Infrastructure\\Ui\\HtmlRender",
+    "name": "Flexi\\Infrastructure\\Ui\\HtmlRender",
     "arguments": [
-      "@CubaDevOps\\Flexi\\Domain\\Interfaces\\TemplateLocatorInterface"
+      "@Flexi\\Domain\\Interfaces\\TemplateLocatorInterface"
     ]
   }
 },
 {
-  "name": "CubaDevOps\\Flexi\\Domain\\Interfaces\\TemplateLocatorInterface",
+  "name": "Flexi\\Domain\\Interfaces\\TemplateLocatorInterface",
   "class": {
-    "name": "CubaDevOps\\Flexi\\Infrastructure\\Ui\\TemplateLocator",
+    "name": "Flexi\\Infrastructure\\Ui\\TemplateLocator",
     "arguments": []
   }
 }
@@ -230,7 +230,7 @@ Then register in `services.json`:
 
 ```json
 {
-  "name": "CubaDevOps\\Flexi\\Domain\\Interfaces\\TemplateLocatorInterface",
+  "name": "Flexi\\Domain\\Interfaces\\TemplateLocatorInterface",
   "class": {
     "name": "YourNamespace\\CustomTemplateLocator",
     "arguments": []

--- a/docs/tests-reorganization.md
+++ b/docs/tests-reorganization.md
@@ -130,18 +130,18 @@ Todos los archivos movidos fueron actualizados con sus nuevos namespaces:
 
 | Nuevo Namespace | Archivos Afectados |
 |-----------------|-------------------|
-| `CubaDevOps\Flexi\Test\Domain\Events` | EventTest.php |
-| `CubaDevOps\Flexi\Test\Domain\Collections` | CollectionTest.php, ObjectCollectionTest.php |
-| `CubaDevOps\Flexi\Test\Domain\ValueObjects` | PlainTextMessageTest.php |
-| `CubaDevOps\Flexi\Test\Domain\Entities` | LogTest.php |
-| `CubaDevOps\Flexi\Test\Infrastructure\Bus` | CommandBusTest.php, EventBusTest.php, QueryBusTest.php |
-| `CubaDevOps\Flexi\Test\Infrastructure\DependencyInjection` | 4 files |
-| `CubaDevOps\Flexi\Test\Infrastructure\Http` | RouterTest.php, RouteTest.php |
-| `CubaDevOps\Flexi\Test\Infrastructure\Ui` | HtmlRenderTest.php, TemplateTest.php |
-| `CubaDevOps\Flexi\Test\Infrastructure\Persistence` | 2 files |
-| `CubaDevOps\Flexi\Test\Infrastructure\Session` | NativeSessionStorageTest.php |
-| `CubaDevOps\Flexi\Test\Application\Commands` | ListCommandsCommandTest.php |
-| `CubaDevOps\Flexi\Test\Application\Queries` | ListQueriesQueryTest.php |
+| `Flexi\Test\Domain\Events` | EventTest.php |
+| `Flexi\Test\Domain\Collections` | CollectionTest.php, ObjectCollectionTest.php |
+| `Flexi\Test\Domain\ValueObjects` | PlainTextMessageTest.php |
+| `Flexi\Test\Domain\Entities` | LogTest.php |
+| `Flexi\Test\Infrastructure\Bus` | CommandBusTest.php, EventBusTest.php, QueryBusTest.php |
+| `Flexi\Test\Infrastructure\DependencyInjection` | 4 files |
+| `Flexi\Test\Infrastructure\Http` | RouterTest.php, RouteTest.php |
+| `Flexi\Test\Infrastructure\Ui` | HtmlRenderTest.php, TemplateTest.php |
+| `Flexi\Test\Infrastructure\Persistence` | 2 files |
+| `Flexi\Test\Infrastructure\Session` | NativeSessionStorageTest.php |
+| `Flexi\Test\Application\Commands` | ListCommandsCommandTest.php |
+| `Flexi\Test\Application\Queries` | ListQueriesQueryTest.php |
 
 ---
 

--- a/docs/tests-update-post-refactoring.md
+++ b/docs/tests-update-post-refactoring.md
@@ -63,7 +63,7 @@ public function handleNotFound(
 
 #### Changes Made
 1. **Removed Imports**:
-   - `CubaDevOps\Flexi\Modules\Logging\Application\EventListeners\LoggerEventListener`
+   - `Flexi\Modules\Logging\Application\EventListeners\LoggerEventListener`
    - `Flexi\Contracts\Interfaces\LogRepositoryInterface`
 
 2. **Added Import**:

--- a/docs/ui-modularization-complete.md
+++ b/docs/ui-modularization-complete.md
@@ -22,20 +22,20 @@ Trasladar el sistema de renderizado de templates del core hacia un módulo dedic
 src/Infrastructure/Ui/Template.php
   ↓ MOVED TO
 modules/Ui/Infrastructure/Ui/Template.php
-  Namespace: CubaDevOps\Flexi\Infrastructure\Ui
-          → CubaDevOps\Flexi\Modules\Ui\Infrastructure\Ui
+  Namespace: Flexi\Infrastructure\Ui
+          → Flexi\Modules\Ui\Infrastructure\Ui
 
 src/Infrastructure/Ui/TemplateLocator.php
   ↓ MOVED TO
 modules/Ui/Infrastructure/Ui/TemplateLocator.php
-  Namespace: CubaDevOps\Flexi\Infrastructure\Ui
-          → CubaDevOps\Flexi\Modules\Ui\Infrastructure\Ui
+  Namespace: Flexi\Infrastructure\Ui
+          → Flexi\Modules\Ui\Infrastructure\Ui
 
 src/Infrastructure/Ui/HtmlRender.php
   ↓ MOVED TO
 modules/Ui/Infrastructure/Ui/HtmlRender.php
-  Namespace: CubaDevOps\Flexi\Infrastructure\Ui
-          → CubaDevOps\Flexi\Modules\Ui\Infrastructure\Ui
+  Namespace: Flexi\Infrastructure\Ui
+          → Flexi\Modules\Ui\Infrastructure\Ui
 ```
 
 #### Tests Movidos (2)
@@ -43,14 +43,14 @@ modules/Ui/Infrastructure/Ui/HtmlRender.php
 tests/Infrastructure/Ui/TemplateTest.php
   ↓ MOVED TO
 modules/Ui/tests/Infrastructure/Ui/TemplateTest.php
-  Namespace: CubaDevOps\Flexi\Test\Infrastructure\Ui
-          → CubaDevOps\Flexi\Test\Modules\Ui\Infrastructure\Ui
+  Namespace: Flexi\Test\Infrastructure\Ui
+          → Flexi\Test\Modules\Ui\Infrastructure\Ui
 
 tests/Infrastructure/Ui/HtmlRenderTest.php
   ↓ MOVED TO
 modules/Ui/tests/Infrastructure/Ui/HtmlRenderTest.php
-  Namespace: CubaDevOps\Flexi\Test\Infrastructure\Ui
-          → CubaDevOps\Flexi\Test\Modules\Ui\Infrastructure\Ui
+  Namespace: Flexi\Test\Infrastructure\Ui
+          → Flexi\Test\Modules\Ui\Infrastructure\Ui
 ```
 
 ### 2. Configuración del Módulo
@@ -62,14 +62,14 @@ modules/Ui/tests/Infrastructure/Ui/HtmlRenderTest.php
     {
       "name": "html_render",
       "class": {
-        "name": "CubaDevOps\\Flexi\\Modules\\Ui\\Infrastructure\\Ui\\HtmlRender",
+        "name": "Flexi\\Modules\\Ui\\Infrastructure\\Ui\\HtmlRender",
         "arguments": ["@Flexi\\Contracts\\Interfaces\\TemplateLocatorInterface"]
       }
     },
     {
       "name": "Flexi\\Contracts\\Interfaces\\TemplateLocatorInterface",
       "class": {
-        "name": "CubaDevOps\\Flexi\\Modules\\Ui\\Infrastructure\\Ui\\TemplateLocator",
+        "name": "Flexi\\Modules\\Ui\\Infrastructure\\Ui\\TemplateLocator",
         "arguments": []
       }
     }
@@ -84,14 +84,14 @@ modules/Ui/tests/Infrastructure/Ui/HtmlRenderTest.php
 - {
 -   "name": "html_render",
 -   "class": {
--     "name": "CubaDevOps\\Flexi\\Infrastructure\\Ui\\HtmlRender",
+-     "name": "Flexi\\Infrastructure\\Ui\\HtmlRender",
 -     "arguments": ["@Flexi\\Contracts\\Interfaces\\TemplateLocatorInterface"]
 -   }
 - },
 - {
 -   "name": "Flexi\\Contracts\\Interfaces\\TemplateLocatorInterface",
 -   "class": {
--     "name": "CubaDevOps\\Flexi\\Infrastructure\\Ui\\TemplateLocator",
+-     "name": "Flexi\\Infrastructure\\Ui\\TemplateLocator",
 -     "arguments": []
 -   }
 - },
@@ -107,8 +107,8 @@ modules/Ui/tests/Infrastructure/Ui/HtmlRenderTest.php
 
 #### `tests/Infrastructure/DependencyInjection/ContainerTest.php`
 ```diff
-- use CubaDevOps\Flexi\Infrastructure\Ui\HtmlRender;
-+ use CubaDevOps\Flexi\Modules\Ui\Infrastructure\Ui\HtmlRender;
+- use Flexi\Infrastructure\Ui\HtmlRender;
++ use Flexi\Modules\Ui\Infrastructure\Ui\HtmlRender;
 ```
 
 #### Otros Archivos

--- a/docs/ui-system-modularization-analysis.md
+++ b/docs/ui-system-modularization-analysis.md
@@ -170,8 +170,8 @@ src/Infrastructure/Ui/HtmlRender.php
 
 **2. Update Namespaces**
 ```
-OLD: CubaDevOps\Flexi\Infrastructure\Ui\Template
-NEW: CubaDevOps\Flexi\Modules\Ui\Infrastructure\Ui\Template
+OLD: Flexi\Infrastructure\Ui\Template
+NEW: Flexi\Modules\Ui\Infrastructure\Ui\Template
 ```
 
 **3. Move Tests**
@@ -195,7 +195,7 @@ contracts/src/Interfaces/TemplateEngineInterface.php
 {
   "name": "html_render",
   "class": {
-    "name": "CubaDevOps\\Flexi\\Modules\\Ui\\Infrastructure\\Ui\\HtmlRender",
+    "name": "Flexi\\Modules\\Ui\\Infrastructure\\Ui\\HtmlRender",
     "arguments": [
       "@Flexi\\Contracts\\Interfaces\\TemplateLocatorInterface"
     ]
@@ -204,7 +204,7 @@ contracts/src/Interfaces/TemplateEngineInterface.php
 {
   "name": "Flexi\\Contracts\\Interfaces\\TemplateLocatorInterface",
   "class": {
-    "name": "CubaDevOps\\Flexi\\Modules\\Ui\\Infrastructure\\Ui\\TemplateLocator",
+    "name": "Flexi\\Modules\\Ui\\Infrastructure\\Ui\\TemplateLocator",
     "arguments": []
   }
 }
@@ -352,26 +352,26 @@ $ Benefit from better architecture
 ```
 src/Infrastructure/Ui/Template.php
   → modules/Ui/Infrastructure/Ui/Template.php
-  Namespace: CubaDevOps\Flexi\Infrastructure\Ui → CubaDevOps\Flexi\Modules\Ui\Infrastructure\Ui
+  Namespace: Flexi\Infrastructure\Ui → Flexi\Modules\Ui\Infrastructure\Ui
 
 src/Infrastructure/Ui/TemplateLocator.php
   → modules/Ui/Infrastructure/Ui/TemplateLocator.php
-  Namespace: CubaDevOps\Flexi\Infrastructure\Ui → CubaDevOps\Flexi\Modules\Ui\Infrastructure\Ui
+  Namespace: Flexi\Infrastructure\Ui → Flexi\Modules\Ui\Infrastructure\Ui
 
 src/Infrastructure/Ui/HtmlRender.php
   → modules/Ui/Infrastructure/Ui/HtmlRender.php
-  Namespace: CubaDevOps\Flexi\Infrastructure\Ui → CubaDevOps\Flexi\Modules\Ui\Infrastructure\Ui
+  Namespace: Flexi\Infrastructure\Ui → Flexi\Modules\Ui\Infrastructure\Ui
 ```
 
 #### Phase 3: Test Migration ✅
 ```
 tests/Infrastructure/Ui/TemplateTest.php
   → modules/Ui/tests/Infrastructure/Ui/TemplateTest.php
-  Namespace: CubaDevOps\Flexi\Test\Infrastructure\Ui → CubaDevOps\Flexi\Test\Modules\Ui\Infrastructure\Ui
+  Namespace: Flexi\Test\Infrastructure\Ui → Flexi\Test\Modules\Ui\Infrastructure\Ui
 
 tests/Infrastructure/Ui/HtmlRenderTest.php
   → modules/Ui/tests/Infrastructure/Ui/HtmlRenderTest.php
-  Namespace: CubaDevOps\Flexi\Test\Infrastructure\Ui → CubaDevOps\Flexi\Test\Modules\Ui\Infrastructure\Ui
+  Namespace: Flexi\Test\Infrastructure\Ui → Flexi\Test\Modules\Ui\Infrastructure\Ui
 ```
 
 #### Phase 4: Configuration Separation ✅
@@ -386,14 +386,14 @@ tests/Infrastructure/Ui/HtmlRenderTest.php
     {
       "name": "html_render",
       "class": {
-        "name": "CubaDevOps\\Flexi\\Modules\\Ui\\Infrastructure\\Ui\\HtmlRender",
+        "name": "Flexi\\Modules\\Ui\\Infrastructure\\Ui\\HtmlRender",
         "arguments": ["@Flexi\\Contracts\\Interfaces\\TemplateLocatorInterface"]
       }
     },
     {
       "name": "Flexi\\Contracts\\Interfaces\\TemplateLocatorInterface",
       "class": {
-        "name": "CubaDevOps\\Flexi\\Modules\\Ui\\Infrastructure\\Ui\\TemplateLocator",
+        "name": "Flexi\\Modules\\Ui\\Infrastructure\\Ui\\TemplateLocator",
         "arguments": []
       }
     }

--- a/docs/valueobjects-order-operator-migration.md
+++ b/docs/valueobjects-order-operator-migration.md
@@ -50,7 +50,7 @@ contracts/src/ValueObjects/
 **1. Operator.php**
 - **De:** `src/Domain/ValueObjects/Operator.php`
 - **A:** `contracts/src/ValueObjects/Operator.php`
-- **Namespace:** `CubaDevOps\Flexi\Domain\ValueObjects` → `Flexi\Contracts\ValueObjects`
+- **Namespace:** `Flexi\Domain\ValueObjects` → `Flexi\Contracts\ValueObjects`
 
 **Contenido:**
 - Constantes: `OPERATORS` (lista de operadores válidos)
@@ -60,7 +60,7 @@ contracts/src/ValueObjects/
 **2. Order.php**
 - **De:** `src/Domain/ValueObjects/Order.php`
 - **A:** `contracts/src/ValueObjects/Order.php`
-- **Namespace:** `CubaDevOps\Flexi\Domain\ValueObjects` → `Flexi\Contracts\ValueObjects`
+- **Namespace:** `Flexi\Domain\ValueObjects` → `Flexi\Contracts\ValueObjects`
 
 **Contenido:**
 - Constantes: `ASC` ('ASC'), `DESC` ('DESC')

--- a/public/index.php
+++ b/public/index.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 ob_start();
 
-use CubaDevOps\Flexi\Infrastructure\Factories\ContainerFactory;
-use CubaDevOps\Flexi\Infrastructure\Ui\Web\Application;
+use Flexi\Infrastructure\Factories\ContainerFactory;
+use Flexi\Infrastructure\Ui\Web\Application;
 
 require_once __DIR__.'/../vendor/autoload.php';
 

--- a/src/Application/Commands/ActivateModuleCommand.php
+++ b/src/Application/Commands/ActivateModuleCommand.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Application\Commands;
+namespace Flexi\Application\Commands;
 
 use Flexi\Contracts\Interfaces\DTOInterface;
 

--- a/src/Application/Commands/DeactivateModuleCommand.php
+++ b/src/Application/Commands/DeactivateModuleCommand.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Application\Commands;
+namespace Flexi\Application\Commands;
 
 use Flexi\Contracts\Interfaces\DTOInterface;
 

--- a/src/Application/Commands/ListModulesCommand.php
+++ b/src/Application/Commands/ListModulesCommand.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Application\Commands;
+namespace Flexi\Application\Commands;
 
 use Flexi\Contracts\Interfaces\CliDTOInterface;
 

--- a/src/Application/Commands/ModuleInfoCommand.php
+++ b/src/Application/Commands/ModuleInfoCommand.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Application\Commands;
+namespace Flexi\Application\Commands;
 
 use Flexi\Contracts\Interfaces\CliDTOInterface;
 

--- a/src/Application/Commands/ModuleStatusCommand.php
+++ b/src/Application/Commands/ModuleStatusCommand.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Application\Commands;
+namespace Flexi\Application\Commands;
 
 use Flexi\Contracts\Interfaces\CliDTOInterface;
 use Flexi\Contracts\Interfaces\DTOInterface;

--- a/src/Application/Commands/UpdateModuleEnvironmentCommand.php
+++ b/src/Application/Commands/UpdateModuleEnvironmentCommand.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Application\Commands;
+namespace Flexi\Application\Commands;
 
 use Flexi\Contracts\Interfaces\DTOInterface;
 

--- a/src/Application/Commands/ValidateModulesCommand.php
+++ b/src/Application/Commands/ValidateModulesCommand.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Application\Commands;
+namespace Flexi\Application\Commands;
 
 use Flexi\Contracts\Interfaces\CliDTOInterface;
 

--- a/src/Application/Services/CommandExecutorInterface.php
+++ b/src/Application/Services/CommandExecutorInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Application\Services;
+namespace Flexi\Application\Services;
 
 /**
  * Interface for executing system commands.

--- a/src/Application/UseCase/ActivateModule.php
+++ b/src/Application/UseCase/ActivateModule.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Application\UseCase;
+namespace Flexi\Application\UseCase;
 
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleStateManagerInterface;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleEnvironmentManagerInterface;
-use CubaDevOps\Flexi\Infrastructure\Factories\HybridModuleDetector;
+use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
+use Flexi\Domain\Interfaces\ModuleEnvironmentManagerInterface;
+use Flexi\Infrastructure\Factories\HybridModuleDetector;
 use Flexi\Contracts\Classes\PlainTextMessage;
 use Flexi\Contracts\Interfaces\DTOInterface;
 use Flexi\Contracts\Interfaces\HandlerInterface;

--- a/src/Application/UseCase/DeactivateModule.php
+++ b/src/Application/UseCase/DeactivateModule.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Application\UseCase;
+namespace Flexi\Application\UseCase;
 
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleStateManagerInterface;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleEnvironmentManagerInterface;
-use CubaDevOps\Flexi\Infrastructure\Factories\HybridModuleDetector;
+use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
+use Flexi\Domain\Interfaces\ModuleEnvironmentManagerInterface;
+use Flexi\Infrastructure\Factories\HybridModuleDetector;
 use Flexi\Contracts\Classes\PlainTextMessage;
 use Flexi\Contracts\Interfaces\DTOInterface;
 use Flexi\Contracts\Interfaces\HandlerInterface;

--- a/src/Application/UseCase/GetModuleInfo.php
+++ b/src/Application/UseCase/GetModuleInfo.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Application\UseCase;
+namespace Flexi\Application\UseCase;
 
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleDetectorInterface;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleStateManagerInterface;
+use Flexi\Domain\Interfaces\ModuleDetectorInterface;
+use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
 use Flexi\Contracts\Classes\PlainTextMessage;
 use Flexi\Contracts\Interfaces\DTOInterface;
 use Flexi\Contracts\Interfaces\HandlerInterface;

--- a/src/Application/UseCase/GetModuleStatus.php
+++ b/src/Application/UseCase/GetModuleStatus.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Application\UseCase;
+namespace Flexi\Application\UseCase;
 
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleDetectorInterface;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleStateManagerInterface;
+use Flexi\Domain\Interfaces\ModuleDetectorInterface;
+use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
 use Flexi\Contracts\Classes\PlainTextMessage;
 use Flexi\Contracts\Interfaces\DTOInterface;
 use Flexi\Contracts\Interfaces\HandlerInterface;

--- a/src/Application/UseCase/ListModules.php
+++ b/src/Application/UseCase/ListModules.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Application\UseCase;
+namespace Flexi\Application\UseCase;
 
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleStateManagerInterface;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleDetectorInterface;
+use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
+use Flexi\Domain\Interfaces\ModuleDetectorInterface;
 use Flexi\Contracts\Classes\PlainTextMessage;
 use Flexi\Contracts\Interfaces\DTOInterface;
 use Flexi\Contracts\Interfaces\HandlerInterface;

--- a/src/Application/UseCase/UpdateModuleEnvironment.php
+++ b/src/Application/UseCase/UpdateModuleEnvironment.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Application\UseCase;
+namespace Flexi\Application\UseCase;
 
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleEnvironmentManagerInterface;
-use CubaDevOps\Flexi\Infrastructure\Factories\HybridModuleDetector;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleStateManagerInterface;
+use Flexi\Domain\Interfaces\ModuleEnvironmentManagerInterface;
+use Flexi\Infrastructure\Factories\HybridModuleDetector;
+use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
 use Flexi\Contracts\Classes\PlainTextMessage;
 use Flexi\Contracts\Interfaces\DTOInterface;
 use Flexi\Contracts\Interfaces\HandlerInterface;

--- a/src/Application/UseCase/ValidateModules.php
+++ b/src/Application/UseCase/ValidateModules.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Application\UseCase;
+namespace Flexi\Application\UseCase;
 
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleDetectorInterface;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleStateManagerInterface;
+use Flexi\Domain\ValueObjects\ModuleInfo;
+use Flexi\Domain\Interfaces\ModuleDetectorInterface;
+use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
 use Flexi\Contracts\Classes\PlainTextMessage;
 use Flexi\Contracts\Interfaces\DTOInterface;
 use Flexi\Contracts\Interfaces\HandlerInterface;

--- a/src/Config/commands.json
+++ b/src/Config/commands.json
@@ -1,39 +1,39 @@
 {
   "handlers": [
     {
-      "id": "CubaDevOps\\Flexi\\Application\\Commands\\ListModulesCommand",
+      "id": "Flexi\\Application\\Commands\\ListModulesCommand",
       "cli_alias": "modules:list",
-      "handler": "CubaDevOps\\Flexi\\Application\\UseCase\\ListModules"
+      "handler": "Flexi\\Application\\UseCase\\ListModules"
     },
     {
-      "id": "CubaDevOps\\Flexi\\Application\\Commands\\ModuleInfoCommand",
+      "id": "Flexi\\Application\\Commands\\ModuleInfoCommand",
       "cli_alias": "modules:info",
-      "handler": "CubaDevOps\\Flexi\\Application\\UseCase\\GetModuleInfo"
+      "handler": "Flexi\\Application\\UseCase\\GetModuleInfo"
     },
     {
-      "id": "CubaDevOps\\Flexi\\Application\\Commands\\ValidateModulesCommand",
+      "id": "Flexi\\Application\\Commands\\ValidateModulesCommand",
       "cli_alias": "modules:validate",
-      "handler": "CubaDevOps\\Flexi\\Application\\UseCase\\ValidateModules"
+      "handler": "Flexi\\Application\\UseCase\\ValidateModules"
     },
     {
-      "id": "CubaDevOps\\Flexi\\Application\\Commands\\ActivateModuleCommand",
+      "id": "Flexi\\Application\\Commands\\ActivateModuleCommand",
       "cli_alias": "modules:activate",
-      "handler": "CubaDevOps\\Flexi\\Application\\UseCase\\ActivateModule"
+      "handler": "Flexi\\Application\\UseCase\\ActivateModule"
     },
     {
-      "id": "CubaDevOps\\Flexi\\Application\\Commands\\DeactivateModuleCommand",
+      "id": "Flexi\\Application\\Commands\\DeactivateModuleCommand",
       "cli_alias": "modules:deactivate",
-      "handler": "CubaDevOps\\Flexi\\Application\\UseCase\\DeactivateModule"
+      "handler": "Flexi\\Application\\UseCase\\DeactivateModule"
     },
     {
-      "id": "CubaDevOps\\Flexi\\Application\\Commands\\ModuleStatusCommand",
+      "id": "Flexi\\Application\\Commands\\ModuleStatusCommand",
       "cli_alias": "modules:status",
-      "handler": "CubaDevOps\\Flexi\\Application\\UseCase\\GetModuleStatus"
+      "handler": "Flexi\\Application\\UseCase\\GetModuleStatus"
     },
     {
-      "id": "CubaDevOps\\Flexi\\Application\\Commands\\UpdateModuleEnvironmentCommand",
+      "id": "Flexi\\Application\\Commands\\UpdateModuleEnvironmentCommand",
       "cli_alias": "modules:env-update",
-      "handler": "CubaDevOps\\Flexi\\Application\\UseCase\\UpdateModuleEnvironment"
+      "handler": "Flexi\\Application\\UseCase\\UpdateModuleEnvironment"
     }
   ]
 }

--- a/src/Config/services.json
+++ b/src/Config/services.json
@@ -3,7 +3,7 @@
     {
       "name": "Flexi\\Contracts\\Interfaces\\ObjectBuilderInterface",
       "class": {
-        "name": "CubaDevOps\\Flexi\\Infrastructure\\Classes\\ObjectBuilder",
+        "name": "Flexi\\Infrastructure\\Classes\\ObjectBuilder",
         "arguments": [
           "@cache"
         ]
@@ -12,14 +12,14 @@
     {
       "name": "Flexi\\Contracts\\Interfaces\\ConfigurationRepositoryInterface",
       "class": {
-        "name": "CubaDevOps\\Flexi\\Infrastructure\\Classes\\ConfigurationRepository",
+        "name": "Flexi\\Infrastructure\\Classes\\ConfigurationRepository",
         "arguments": []
       }
     },
     {
       "name": "Flexi\\Contracts\\Interfaces\\ConfigurationInterface",
       "class": {
-        "name": "CubaDevOps\\Flexi\\Infrastructure\\Classes\\Configuration",
+        "name": "Flexi\\Infrastructure\\Classes\\Configuration",
         "arguments": [
           "@Flexi\\Contracts\\Interfaces\\ConfigurationRepositoryInterface"
         ]
@@ -27,9 +27,9 @@
     },
 
     {
-      "name": "CubaDevOps\\Flexi\\Infrastructure\\Factories\\RouterFactory",
+      "name": "Flexi\\Infrastructure\\Factories\\RouterFactory",
       "factory": {
-        "class": "CubaDevOps\\Flexi\\Infrastructure\\Factories\\RouterFactory",
+        "class": "Flexi\\Infrastructure\\Factories\\RouterFactory",
         "method": "create",
         "arguments": [
           "@container"
@@ -38,12 +38,12 @@
     },
     {
       "name": "router",
-      "alias": "CubaDevOps\\Flexi\\Infrastructure\\Factories\\RouterFactory"
+      "alias": "Flexi\\Infrastructure\\Factories\\RouterFactory"
     },
     {
-      "name": "CubaDevOps\\Flexi\\Infrastructure\\Bus\\CommandBus",
+      "name": "Flexi\\Infrastructure\\Bus\\CommandBus",
       "factory": {
-        "class": "CubaDevOps\\Flexi\\Infrastructure\\Factories\\BusFactory",
+        "class": "Flexi\\Infrastructure\\Factories\\BusFactory",
         "method": "createCommandBus",
         "arguments": [
           "@container"
@@ -52,12 +52,12 @@
     },
     {
       "name": "command_bus",
-      "alias": "CubaDevOps\\Flexi\\Infrastructure\\Bus\\CommandBus"
+      "alias": "Flexi\\Infrastructure\\Bus\\CommandBus"
     },
     {
-      "name": "CubaDevOps\\Flexi\\Infrastructure\\Bus\\QueryBus",
+      "name": "Flexi\\Infrastructure\\Bus\\QueryBus",
       "factory": {
-        "class": "CubaDevOps\\Flexi\\Infrastructure\\Factories\\BusFactory",
+        "class": "Flexi\\Infrastructure\\Factories\\BusFactory",
         "method": "createQueryBus",
         "arguments": [
           "@container"
@@ -66,12 +66,12 @@
     },
     {
       "name": "query_bus",
-      "alias": "CubaDevOps\\Flexi\\Infrastructure\\Bus\\QueryBus"
+      "alias": "Flexi\\Infrastructure\\Bus\\QueryBus"
     },
     {
-      "name": "CubaDevOps\\Flexi\\Infrastructure\\Bus\\EventBus",
+      "name": "Flexi\\Infrastructure\\Bus\\EventBus",
       "factory": {
-        "class": "CubaDevOps\\Flexi\\Infrastructure\\Factories\\BusFactory",
+        "class": "Flexi\\Infrastructure\\Factories\\BusFactory",
         "method": "createEventBus",
         "arguments": [
           "@container"
@@ -80,7 +80,7 @@
     },
     {
       "name": "Flexi\\Contracts\\Interfaces\\EventBusInterface",
-      "alias": "CubaDevOps\\Flexi\\Infrastructure\\Bus\\EventBus"
+      "alias": "Flexi\\Infrastructure\\Bus\\EventBus"
     },
     {
       "name": "Psr\\Http\\Message\\ResponseFactoryInterface",
@@ -97,16 +97,16 @@
       }
     },
     {
-      "name": "CubaDevOps\\Flexi\\Application\\Services\\CommandExecutorInterface",
+      "name": "Flexi\\Application\\Services\\CommandExecutorInterface",
       "class": {
-        "name": "CubaDevOps\\Flexi\\Infrastructure\\Services\\CommandExecutor",
+        "name": "Flexi\\Infrastructure\\Services\\CommandExecutor",
         "arguments": []
       }
     },
     {
-      "name": "CubaDevOps\\Flexi\\Domain\\Interfaces\\ModuleCacheManagerInterface",
+      "name": "Flexi\\Domain\\Interfaces\\ModuleCacheManagerInterface",
       "class": {
-        "name": "CubaDevOps\\Flexi\\Infrastructure\\Classes\\ModuleCacheManager",
+        "name": "Flexi\\Infrastructure\\Classes\\ModuleCacheManager",
         "arguments": [
           "./var",
           "./"
@@ -114,137 +114,137 @@
       }
     },
     {
-      "name": "CubaDevOps\\Flexi\\Infrastructure\\Classes\\ModuleStateRepository",
+      "name": "Flexi\\Infrastructure\\Classes\\ModuleStateRepository",
       "class": {
-        "name": "CubaDevOps\\Flexi\\Infrastructure\\Classes\\ModuleStateRepository",
+        "name": "Flexi\\Infrastructure\\Classes\\ModuleStateRepository",
         "arguments": [
           "./var/modules-state.json"
         ]
       }
     },
     {
-      "name": "CubaDevOps\\Flexi\\Domain\\Interfaces\\ModuleStateManagerInterface",
+      "name": "Flexi\\Domain\\Interfaces\\ModuleStateManagerInterface",
       "class": {
-        "name": "CubaDevOps\\Flexi\\Infrastructure\\Classes\\ModuleStateManager",
+        "name": "Flexi\\Infrastructure\\Classes\\ModuleStateManager",
         "arguments": [
-          "@CubaDevOps\\Flexi\\Infrastructure\\Classes\\ModuleStateRepository"
+          "@Flexi\\Infrastructure\\Classes\\ModuleStateRepository"
         ]
       }
     },
     {
-      "name": "CubaDevOps\\Flexi\\Infrastructure\\Factories\\LocalModuleDetector",
+      "name": "Flexi\\Infrastructure\\Factories\\LocalModuleDetector",
       "class": {
-        "name": "CubaDevOps\\Flexi\\Infrastructure\\Factories\\LocalModuleDetector",
+        "name": "Flexi\\Infrastructure\\Factories\\LocalModuleDetector",
         "arguments": [
           "./modules"
         ]
       }
     },
     {
-      "name": "CubaDevOps\\Flexi\\Infrastructure\\Factories\\VendorModuleDetector",
+      "name": "Flexi\\Infrastructure\\Factories\\VendorModuleDetector",
       "class": {
-        "name": "CubaDevOps\\Flexi\\Infrastructure\\Factories\\VendorModuleDetector",
+        "name": "Flexi\\Infrastructure\\Factories\\VendorModuleDetector",
         "arguments": [
-          "@CubaDevOps\\Flexi\\Domain\\Interfaces\\ModuleCacheManagerInterface",
+          "@Flexi\\Domain\\Interfaces\\ModuleCacheManagerInterface",
           "./vendor"
         ]
       }
     },
     {
-      "name": "CubaDevOps\\Flexi\\Infrastructure\\Factories\\HybridModuleDetector",
+      "name": "Flexi\\Infrastructure\\Factories\\HybridModuleDetector",
       "class": {
-        "name": "CubaDevOps\\Flexi\\Infrastructure\\Factories\\HybridModuleDetector",
+        "name": "Flexi\\Infrastructure\\Factories\\HybridModuleDetector",
         "arguments": [
-          "@CubaDevOps\\Flexi\\Infrastructure\\Factories\\LocalModuleDetector",
-          "@CubaDevOps\\Flexi\\Infrastructure\\Factories\\VendorModuleDetector"
+          "@Flexi\\Infrastructure\\Factories\\LocalModuleDetector",
+          "@Flexi\\Infrastructure\\Factories\\VendorModuleDetector"
         ]
       }
     },
     {
-      "name": "CubaDevOps\\Flexi\\Domain\\Interfaces\\ModuleDetectorInterface",
-      "alias": "CubaDevOps\\Flexi\\Infrastructure\\Factories\\HybridModuleDetector"
+      "name": "Flexi\\Domain\\Interfaces\\ModuleDetectorInterface",
+      "alias": "Flexi\\Infrastructure\\Factories\\HybridModuleDetector"
     },
     {
-      "name": "CubaDevOps\\Flexi\\Domain\\Interfaces\\ModuleEnvironmentManagerInterface",
-      "alias": "CubaDevOps\\Flexi\\Infrastructure\\Classes\\ModuleEnvironmentManager"
+      "name": "Flexi\\Domain\\Interfaces\\ModuleEnvironmentManagerInterface",
+      "alias": "Flexi\\Infrastructure\\Classes\\ModuleEnvironmentManager"
     },
     {
-      "name": "CubaDevOps\\Flexi\\Infrastructure\\Classes\\ModuleEnvironmentManager",
+      "name": "Flexi\\Infrastructure\\Classes\\ModuleEnvironmentManager",
       "class": {
-        "name": "CubaDevOps\\Flexi\\Infrastructure\\Classes\\ModuleEnvironmentManager",
+        "name": "Flexi\\Infrastructure\\Classes\\ModuleEnvironmentManager",
         "arguments": [
           "@Flexi\\Contracts\\Interfaces\\ConfigurationInterface"
         ]
       }
     },
     {
-      "name": "CubaDevOps\\Flexi\\Application\\UseCase\\ActivateModule",
+      "name": "Flexi\\Application\\UseCase\\ActivateModule",
       "class": {
-        "name": "CubaDevOps\\Flexi\\Application\\UseCase\\ActivateModule",
+        "name": "Flexi\\Application\\UseCase\\ActivateModule",
         "arguments": [
-          "@CubaDevOps\\Flexi\\Domain\\Interfaces\\ModuleStateManagerInterface",
-          "@CubaDevOps\\Flexi\\Infrastructure\\Factories\\HybridModuleDetector",
-          "@CubaDevOps\\Flexi\\Domain\\Interfaces\\ModuleEnvironmentManagerInterface"
+          "@Flexi\\Domain\\Interfaces\\ModuleStateManagerInterface",
+          "@Flexi\\Infrastructure\\Factories\\HybridModuleDetector",
+          "@Flexi\\Domain\\Interfaces\\ModuleEnvironmentManagerInterface"
         ]
       }
     },
     {
-      "name": "CubaDevOps\\Flexi\\Application\\UseCase\\DeactivateModule",
+      "name": "Flexi\\Application\\UseCase\\DeactivateModule",
       "class": {
-        "name": "CubaDevOps\\Flexi\\Application\\UseCase\\DeactivateModule",
+        "name": "Flexi\\Application\\UseCase\\DeactivateModule",
         "arguments": [
-          "@CubaDevOps\\Flexi\\Domain\\Interfaces\\ModuleStateManagerInterface",
-          "@CubaDevOps\\Flexi\\Infrastructure\\Factories\\HybridModuleDetector",
-          "@CubaDevOps\\Flexi\\Domain\\Interfaces\\ModuleEnvironmentManagerInterface"
+          "@Flexi\\Domain\\Interfaces\\ModuleStateManagerInterface",
+          "@Flexi\\Infrastructure\\Factories\\HybridModuleDetector",
+          "@Flexi\\Domain\\Interfaces\\ModuleEnvironmentManagerInterface"
         ]
       }
     },
     {
-      "name": "CubaDevOps\\Flexi\\Application\\UseCase\\GetModuleStatus",
+      "name": "Flexi\\Application\\UseCase\\GetModuleStatus",
       "class": {
-        "name": "CubaDevOps\\Flexi\\Application\\UseCase\\GetModuleStatus",
+        "name": "Flexi\\Application\\UseCase\\GetModuleStatus",
         "arguments": [
-          "@CubaDevOps\\Flexi\\Domain\\Interfaces\\ModuleStateManagerInterface",
-          "@CubaDevOps\\Flexi\\Infrastructure\\Factories\\HybridModuleDetector"
+          "@Flexi\\Domain\\Interfaces\\ModuleStateManagerInterface",
+          "@Flexi\\Infrastructure\\Factories\\HybridModuleDetector"
         ]
       }
     },
     {
-      "name": "CubaDevOps\\Flexi\\Application\\UseCase\\UpdateModuleEnvironment",
+      "name": "Flexi\\Application\\UseCase\\UpdateModuleEnvironment",
       "class": {
-        "name": "CubaDevOps\\Flexi\\Application\\UseCase\\UpdateModuleEnvironment",
+        "name": "Flexi\\Application\\UseCase\\UpdateModuleEnvironment",
         "arguments": [
-          "@CubaDevOps\\Flexi\\Domain\\Interfaces\\ModuleEnvironmentManagerInterface",
-          "@CubaDevOps\\Flexi\\Infrastructure\\Factories\\HybridModuleDetector",
-          "@CubaDevOps\\Flexi\\Domain\\Interfaces\\ModuleStateManagerInterface"
+          "@Flexi\\Domain\\Interfaces\\ModuleEnvironmentManagerInterface",
+          "@Flexi\\Infrastructure\\Factories\\HybridModuleDetector",
+          "@Flexi\\Domain\\Interfaces\\ModuleStateManagerInterface"
         ]
       }
     },
     {
-      "name": "CubaDevOps\\Flexi\\Application\\UseCase\\ListModules",
+      "name": "Flexi\\Application\\UseCase\\ListModules",
       "class": {
-        "name": "CubaDevOps\\Flexi\\Application\\UseCase\\ListModules",
+        "name": "Flexi\\Application\\UseCase\\ListModules",
         "arguments": [
-          "@CubaDevOps\\Flexi\\Domain\\Interfaces\\ModuleStateManagerInterface",
-          "@CubaDevOps\\Flexi\\Infrastructure\\Factories\\HybridModuleDetector"
+          "@Flexi\\Domain\\Interfaces\\ModuleStateManagerInterface",
+          "@Flexi\\Infrastructure\\Factories\\HybridModuleDetector"
         ]
       }
     },
     {
-      "name": "CubaDevOps\\Flexi\\Domain\\Interfaces\\ConfigurationFilesProviderInterface",
+      "name": "Flexi\\Domain\\Interfaces\\ConfigurationFilesProviderInterface",
       "class": {
-        "name": "CubaDevOps\\Flexi\\Infrastructure\\Classes\\ConfigurationFilesProvider",
+        "name": "Flexi\\Infrastructure\\Classes\\ConfigurationFilesProvider",
         "arguments": [
-          "@CubaDevOps\\Flexi\\Domain\\Interfaces\\ModuleStateManagerInterface",
-          "@CubaDevOps\\Flexi\\Infrastructure\\Factories\\HybridModuleDetector",
+          "@Flexi\\Domain\\Interfaces\\ModuleStateManagerInterface",
+          "@Flexi\\Infrastructure\\Factories\\HybridModuleDetector",
           "./"
         ]
       }
     },
     {
-      "name": "CubaDevOps\\Flexi\\Infrastructure\\DependencyInjection\\RoutesDefinitionParser",
+      "name": "Flexi\\Infrastructure\\DependencyInjection\\RoutesDefinitionParser",
       "class": {
-        "name": "CubaDevOps\\Flexi\\Infrastructure\\DependencyInjection\\RoutesDefinitionParser",
+        "name": "Flexi\\Infrastructure\\DependencyInjection\\RoutesDefinitionParser",
         "arguments": [
           "@cache"
         ]

--- a/src/Domain/Commands/NotFoundCommand.php
+++ b/src/Domain/Commands/NotFoundCommand.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Domain\Commands;
+namespace Flexi\Domain\Commands;
 
 use Flexi\Contracts\Interfaces\DTOInterface;
 

--- a/src/Domain/Events/Event.php
+++ b/src/Domain/Events/Event.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Domain\Events;
+namespace Flexi\Domain\Events;
 
 use Flexi\Contracts\Interfaces\EventInterface;
 

--- a/src/Domain/Events/RouteNotFoundEvent.php
+++ b/src/Domain/Events/RouteNotFoundEvent.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Domain\Events;
+namespace Flexi\Domain\Events;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;

--- a/src/Domain/Exceptions/ContainerException.php
+++ b/src/Domain/Exceptions/ContainerException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Domain\Exceptions;
+namespace Flexi\Domain\Exceptions;
 
 use Psr\Container\NotFoundExceptionInterface;
 

--- a/src/Domain/Exceptions/InvalidArgumentCacheException.php
+++ b/src/Domain/Exceptions/InvalidArgumentCacheException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Domain\Exceptions;
+namespace Flexi\Domain\Exceptions;
 
 use Psr\SimpleCache\InvalidArgumentException;
 

--- a/src/Domain/Exceptions/ServiceNotFoundException.php
+++ b/src/Domain/Exceptions/ServiceNotFoundException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Domain\Exceptions;
+namespace Flexi\Domain\Exceptions;
 
 use Psr\Container\NotFoundExceptionInterface;
 

--- a/src/Domain/Interfaces/ConfigurationFilesProviderInterface.php
+++ b/src/Domain/Interfaces/ConfigurationFilesProviderInterface.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Domain\Interfaces;
+namespace Flexi\Domain\Interfaces;
 
-use CubaDevOps\Flexi\Domain\ValueObjects\ConfigurationType;
+use Flexi\Domain\ValueObjects\ConfigurationType;
 
 /**
  * Interface for providing configuration files from active modules

--- a/src/Domain/Interfaces/ModuleCacheManagerInterface.php
+++ b/src/Domain/Interfaces/ModuleCacheManagerInterface.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Domain\Interfaces;
+namespace Flexi\Domain\Interfaces;
 
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo;
+use Flexi\Domain\ValueObjects\ModuleInfo;
 
 /**
  * Interface for managing module discovery cache.

--- a/src/Domain/Interfaces/ModuleDetectorInterface.php
+++ b/src/Domain/Interfaces/ModuleDetectorInterface.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Domain\Interfaces;
+namespace Flexi\Domain\Interfaces;
 
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo;
+use Flexi\Domain\ValueObjects\ModuleInfo;
 
 /**
  * Interface for module detection

--- a/src/Domain/Interfaces/ModuleEnvironmentManagerInterface.php
+++ b/src/Domain/Interfaces/ModuleEnvironmentManagerInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Domain\Interfaces;
+namespace Flexi\Domain\Interfaces;
 
 /**
  * Interface for managing module environment variables.

--- a/src/Domain/Interfaces/ModuleStateManagerInterface.php
+++ b/src/Domain/Interfaces/ModuleStateManagerInterface.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Domain\Interfaces;
+namespace Flexi\Domain\Interfaces;
 
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleState;
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleType;
+use Flexi\Domain\ValueObjects\ModuleState;
+use Flexi\Domain\ValueObjects\ModuleType;
 
 /**
  * Interface for managing the activation state of modules.

--- a/src/Domain/ValueObjects/ConfigurationType.php
+++ b/src/Domain/ValueObjects/ConfigurationType.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Domain\ValueObjects;
+namespace Flexi\Domain\ValueObjects;
 
 /**
  * Value Object representing a configuration file type

--- a/src/Domain/ValueObjects/ModuleInfo.php
+++ b/src/Domain/ValueObjects/ModuleInfo.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Domain\ValueObjects;
+namespace Flexi\Domain\ValueObjects;
 
 /**
  * Value Object representing complete information about a module.

--- a/src/Domain/ValueObjects/ModuleState.php
+++ b/src/Domain/ValueObjects/ModuleState.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Domain\ValueObjects;
+namespace Flexi\Domain\ValueObjects;
 
 use DateTimeImmutable;
 

--- a/src/Domain/ValueObjects/ModuleType.php
+++ b/src/Domain/ValueObjects/ModuleType.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Domain\ValueObjects;
+namespace Flexi\Domain\ValueObjects;
 
 /**
  * Class representing the type of module installation.

--- a/src/Domain/ValueObjects/ServiceType.php
+++ b/src/Domain/ValueObjects/ServiceType.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Domain\ValueObjects;
+namespace Flexi\Domain\ValueObjects;
 
 use Flexi\Contracts\Interfaces\ValueObjectInterface;
 

--- a/src/Infrastructure/Bus/CommandBus.php
+++ b/src/Infrastructure/Bus/CommandBus.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Bus;
+namespace Flexi\Infrastructure\Bus;
 
 use Flexi\Contracts\Interfaces\BusInterface;
 use Flexi\Contracts\Interfaces\DTOInterface;
@@ -10,8 +10,8 @@ use Flexi\Contracts\Interfaces\EventBusInterface;
 use Flexi\Contracts\Interfaces\HandlerInterface;
 use Flexi\Contracts\Interfaces\MessageInterface;
 use Flexi\Contracts\Interfaces\ObjectBuilderInterface;
-use CubaDevOps\Flexi\Domain\Commands\NotFoundCommand;
-use CubaDevOps\Flexi\Domain\Events\Event;
+use Flexi\Domain\Commands\NotFoundCommand;
+use Flexi\Domain\Events\Event;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;

--- a/src/Infrastructure/Bus/EventBus.php
+++ b/src/Infrastructure/Bus/EventBus.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Bus;
+namespace Flexi\Infrastructure\Bus;
 
 use Flexi\Contracts\Classes\Traits\GlobFileReader;
 use Flexi\Contracts\Classes\Traits\JsonFileReader;
@@ -12,7 +12,7 @@ use Flexi\Contracts\Interfaces\EventBusInterface;
 use Flexi\Contracts\Interfaces\EventInterface;
 use Flexi\Contracts\Interfaces\EventListenerInterface;
 use Flexi\Contracts\Interfaces\ObjectBuilderInterface;
-use CubaDevOps\Flexi\Domain\Commands\NotFoundCommand;
+use Flexi\Domain\Commands\NotFoundCommand;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;

--- a/src/Infrastructure/Bus/QueryBus.php
+++ b/src/Infrastructure/Bus/QueryBus.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Bus;
+namespace Flexi\Infrastructure\Bus;
 
 use Flexi\Contracts\Interfaces\BusInterface;
 use Flexi\Contracts\Interfaces\DTOInterface;
@@ -10,8 +10,8 @@ use Flexi\Contracts\Interfaces\EventBusInterface;
 use Flexi\Contracts\Interfaces\HandlerInterface;
 use Flexi\Contracts\Interfaces\MessageInterface;
 use Flexi\Contracts\Interfaces\ObjectBuilderInterface;
-use CubaDevOps\Flexi\Domain\Commands\NotFoundCommand;
-use CubaDevOps\Flexi\Domain\Events\Event;
+use Flexi\Domain\Commands\NotFoundCommand;
+use Flexi\Domain\Events\Event;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;

--- a/src/Infrastructure/Classes/Configuration.php
+++ b/src/Infrastructure/Classes/Configuration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Classes;
+namespace Flexi\Infrastructure\Classes;
 
 use Flexi\Contracts\Interfaces\ConfigurationInterface;
 use Flexi\Contracts\Interfaces\ConfigurationRepositoryInterface;

--- a/src/Infrastructure/Classes/ConfigurationFilesProvider.php
+++ b/src/Infrastructure/Classes/ConfigurationFilesProvider.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Classes;
+namespace Flexi\Infrastructure\Classes;
 
-use CubaDevOps\Flexi\Domain\Interfaces\ConfigurationFilesProviderInterface;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleStateManagerInterface;
-use CubaDevOps\Flexi\Infrastructure\Factories\HybridModuleDetector;
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo;
-use CubaDevOps\Flexi\Domain\ValueObjects\ConfigurationType;
+use Flexi\Domain\Interfaces\ConfigurationFilesProviderInterface;
+use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
+use Flexi\Infrastructure\Factories\HybridModuleDetector;
+use Flexi\Domain\ValueObjects\ModuleInfo;
+use Flexi\Domain\ValueObjects\ConfigurationType;
 use Flexi\Contracts\Classes\Traits\FileHandlerTrait;
 
 /**

--- a/src/Infrastructure/Classes/ConfigurationRepository.php
+++ b/src/Infrastructure/Classes/ConfigurationRepository.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Classes;
+namespace Flexi\Infrastructure\Classes;
 
 use Flexi\Contracts\Classes\Collection;
 use Flexi\Contracts\Interfaces\ConfigurationRepositoryInterface;

--- a/src/Infrastructure/Classes/InMemoryCache.php
+++ b/src/Infrastructure/Classes/InMemoryCache.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Classes;
+namespace Flexi\Infrastructure\Classes;
 
 use Flexi\Contracts\Interfaces\CacheInterface;
-use CubaDevOps\Flexi\Domain\Exceptions\InvalidArgumentCacheException;
+use Flexi\Domain\Exceptions\InvalidArgumentCacheException;
 
 class InMemoryCache implements CacheInterface
 {

--- a/src/Infrastructure/Classes/ModuleCacheManager.php
+++ b/src/Infrastructure/Classes/ModuleCacheManager.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Classes;
+namespace Flexi\Infrastructure\Classes;
 
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleCacheManagerInterface;
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo;
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleType;
+use Flexi\Domain\Interfaces\ModuleCacheManagerInterface;
+use Flexi\Domain\ValueObjects\ModuleInfo;
+use Flexi\Domain\ValueObjects\ModuleType;
 
 /**
  * Manages module discovery cache based on composer.lock changes.

--- a/src/Infrastructure/Classes/ModuleEnvironmentManager.php
+++ b/src/Infrastructure/Classes/ModuleEnvironmentManager.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Classes;
+namespace Flexi\Infrastructure\Classes;
 
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleEnvironmentManagerInterface;
+use Flexi\Domain\Interfaces\ModuleEnvironmentManagerInterface;
 use Flexi\Contracts\Interfaces\ConfigurationInterface;
 use Dotenv\Dotenv;
 

--- a/src/Infrastructure/Classes/ModuleStateManager.php
+++ b/src/Infrastructure/Classes/ModuleStateManager.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Classes;
+namespace Flexi\Infrastructure\Classes;
 
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleState;
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleType;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleStateManagerInterface;
+use Flexi\Domain\ValueObjects\ModuleState;
+use Flexi\Domain\ValueObjects\ModuleType;
+use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
 
 /**
  * Manages the activation state of modules.

--- a/src/Infrastructure/Classes/ModuleStateRepository.php
+++ b/src/Infrastructure/Classes/ModuleStateRepository.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Classes;
+namespace Flexi\Infrastructure\Classes;
 
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleState;
+use Flexi\Domain\ValueObjects\ModuleState;
 use DateTimeImmutable;
 
 /**

--- a/src/Infrastructure/Classes/ObjectBuilder.php
+++ b/src/Infrastructure/Classes/ObjectBuilder.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Classes;
+namespace Flexi\Infrastructure\Classes;
 
 use Flexi\Contracts\Classes\Traits\CacheKeyGeneratorTrait;
 use Flexi\Contracts\Interfaces\CacheInterface;

--- a/src/Infrastructure/DependencyInjection/Container.php
+++ b/src/Infrastructure/DependencyInjection/Container.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\DependencyInjection;
+namespace Flexi\Infrastructure\DependencyInjection;
 
 use Flexi\Contracts\Interfaces\CacheInterface;
 use Flexi\Contracts\Interfaces\ObjectBuilderInterface;
-use CubaDevOps\Flexi\Domain\Exceptions\ServiceNotFoundException;
+use Flexi\Domain\Exceptions\ServiceNotFoundException;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;

--- a/src/Infrastructure/DependencyInjection/HandlersDefinitionParser.php
+++ b/src/Infrastructure/DependencyInjection/HandlersDefinitionParser.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\DependencyInjection;
+namespace Flexi\Infrastructure\DependencyInjection;
 
 use Flexi\Contracts\Classes\Traits\FileHandlerTrait;
 use Flexi\Contracts\Classes\Traits\JsonFileReader;

--- a/src/Infrastructure/DependencyInjection/ListenersDefinitionParser.php
+++ b/src/Infrastructure/DependencyInjection/ListenersDefinitionParser.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\DependencyInjection;
+namespace Flexi\Infrastructure\DependencyInjection;
 
 use Flexi\Contracts\Classes\Traits\FileHandlerTrait;
 use Flexi\Contracts\Classes\Traits\JsonFileReader;

--- a/src/Infrastructure/DependencyInjection/RoutesDefinitionParser.php
+++ b/src/Infrastructure/DependencyInjection/RoutesDefinitionParser.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\DependencyInjection;
+namespace Flexi\Infrastructure\DependencyInjection;
 
 use Flexi\Contracts\Classes\Traits\FileHandlerTrait;
 use Flexi\Contracts\Classes\Traits\JsonFileReader;
 use Flexi\Contracts\Interfaces\CacheInterface;
-use CubaDevOps\Flexi\Infrastructure\Http\Route;
+use Flexi\Infrastructure\Http\Route;
 
 class RoutesDefinitionParser
 {

--- a/src/Infrastructure/DependencyInjection/Service.php
+++ b/src/Infrastructure/DependencyInjection/Service.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\DependencyInjection;
+namespace Flexi\Infrastructure\DependencyInjection;
 
 use Flexi\Contracts\Interfaces\ServiceDefinitionInterface;
-use CubaDevOps\Flexi\Domain\ValueObjects\ServiceType;
+use Flexi\Domain\ValueObjects\ServiceType;
 
 class Service
 {

--- a/src/Infrastructure/DependencyInjection/ServiceClassDefinition.php
+++ b/src/Infrastructure/DependencyInjection/ServiceClassDefinition.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\DependencyInjection;
+namespace Flexi\Infrastructure\DependencyInjection;
 
 use Flexi\Contracts\Interfaces\ServiceDefinitionInterface;
 

--- a/src/Infrastructure/DependencyInjection/ServiceFactoryDefinition.php
+++ b/src/Infrastructure/DependencyInjection/ServiceFactoryDefinition.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\DependencyInjection;
+namespace Flexi\Infrastructure\DependencyInjection;
 
 use Flexi\Contracts\Interfaces\ServiceDefinitionInterface;
 

--- a/src/Infrastructure/DependencyInjection/ServicesDefinitionParser.php
+++ b/src/Infrastructure/DependencyInjection/ServicesDefinitionParser.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\DependencyInjection;
+namespace Flexi\Infrastructure\DependencyInjection;
 
 use Flexi\Contracts\Classes\Traits\FileHandlerTrait;
 use Flexi\Contracts\Classes\Traits\GlobFileReader;

--- a/src/Infrastructure/Factories/BusFactory.php
+++ b/src/Infrastructure/Factories/BusFactory.php
@@ -2,19 +2,19 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Factories;
+namespace Flexi\Infrastructure\Factories;
 
 use Flexi\Contracts\Interfaces\BusInterface;
 use Flexi\Contracts\Interfaces\ConfigurationRepositoryInterface;
 use Flexi\Contracts\Interfaces\EventBusInterface;
 use Flexi\Contracts\Interfaces\ObjectBuilderInterface;
-use CubaDevOps\Flexi\Infrastructure\Bus\CommandBus;
-use CubaDevOps\Flexi\Infrastructure\Bus\EventBus;
-use CubaDevOps\Flexi\Infrastructure\Bus\QueryBus;
-use CubaDevOps\Flexi\Domain\Interfaces\ConfigurationFilesProviderInterface;
-use CubaDevOps\Flexi\Infrastructure\DependencyInjection\HandlersDefinitionParser;
-use CubaDevOps\Flexi\Infrastructure\DependencyInjection\ListenersDefinitionParser;
-use CubaDevOps\Flexi\Domain\ValueObjects\ConfigurationType;
+use Flexi\Infrastructure\Bus\CommandBus;
+use Flexi\Infrastructure\Bus\EventBus;
+use Flexi\Infrastructure\Bus\QueryBus;
+use Flexi\Domain\Interfaces\ConfigurationFilesProviderInterface;
+use Flexi\Infrastructure\DependencyInjection\HandlersDefinitionParser;
+use Flexi\Infrastructure\DependencyInjection\ListenersDefinitionParser;
+use Flexi\Domain\ValueObjects\ConfigurationType;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;

--- a/src/Infrastructure/Factories/CacheFactoryInterface.php
+++ b/src/Infrastructure/Factories/CacheFactoryInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Factories;
+namespace Flexi\Infrastructure\Factories;
 
 use Flexi\Contracts\Interfaces\CacheInterface;
 

--- a/src/Infrastructure/Factories/ContainerFactory.php
+++ b/src/Infrastructure/Factories/ContainerFactory.php
@@ -2,21 +2,21 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Factories;
+namespace Flexi\Infrastructure\Factories;
 
-use CubaDevOps\Flexi\Infrastructure\Classes\ModuleCacheManager;
-use CubaDevOps\Flexi\Infrastructure\Classes\ModuleStateRepository;
+use Flexi\Infrastructure\Classes\ModuleCacheManager;
+use Flexi\Infrastructure\Classes\ModuleStateRepository;
 use Flexi\Contracts\Interfaces\CacheInterface;
 use Flexi\Contracts\Interfaces\ObjectBuilderInterface;
-use CubaDevOps\Flexi\Infrastructure\DependencyInjection\ServicesDefinitionParser;
-use CubaDevOps\Flexi\Infrastructure\Classes\Configuration;
-use CubaDevOps\Flexi\Infrastructure\Classes\ConfigurationRepository;
-use CubaDevOps\Flexi\Infrastructure\Classes\ObjectBuilder;
-use CubaDevOps\Flexi\Infrastructure\DependencyInjection\Container;
-use CubaDevOps\Flexi\Domain\Interfaces\ConfigurationFilesProviderInterface;
-use CubaDevOps\Flexi\Domain\ValueObjects\ConfigurationType;
-use CubaDevOps\Flexi\Infrastructure\Classes\ConfigurationFilesProvider;
-use CubaDevOps\Flexi\Infrastructure\Classes\ModuleStateManager;
+use Flexi\Infrastructure\DependencyInjection\ServicesDefinitionParser;
+use Flexi\Infrastructure\Classes\Configuration;
+use Flexi\Infrastructure\Classes\ConfigurationRepository;
+use Flexi\Infrastructure\Classes\ObjectBuilder;
+use Flexi\Infrastructure\DependencyInjection\Container;
+use Flexi\Domain\Interfaces\ConfigurationFilesProviderInterface;
+use Flexi\Domain\ValueObjects\ConfigurationType;
+use Flexi\Infrastructure\Classes\ConfigurationFilesProvider;
+use Flexi\Infrastructure\Classes\ModuleStateManager;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 

--- a/src/Infrastructure/Factories/DefaultCacheFactory.php
+++ b/src/Infrastructure/Factories/DefaultCacheFactory.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Factories;
+namespace Flexi\Infrastructure\Factories;
 
-use CubaDevOps\Flexi\Infrastructure\Classes\Configuration;
-use CubaDevOps\Flexi\Infrastructure\Classes\InMemoryCache;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleDetectorInterface;
+use Flexi\Infrastructure\Classes\Configuration;
+use Flexi\Infrastructure\Classes\InMemoryCache;
+use Flexi\Domain\Interfaces\ModuleDetectorInterface;
 use Flexi\Contracts\Interfaces\CacheInterface;
 use Psr\Container\ContainerInterface;
 

--- a/src/Infrastructure/Factories/HybridModuleDetector.php
+++ b/src/Infrastructure/Factories/HybridModuleDetector.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Factories;
+namespace Flexi\Infrastructure\Factories;
 
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo;
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleType;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleDetectorInterface;
+use Flexi\Domain\ValueObjects\ModuleInfo;
+use Flexi\Domain\ValueObjects\ModuleType;
+use Flexi\Domain\Interfaces\ModuleDetectorInterface;
 
 /**
  * Hybrid module detector that combines local and vendor module detection.

--- a/src/Infrastructure/Factories/LocalModuleDetector.php
+++ b/src/Infrastructure/Factories/LocalModuleDetector.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Factories;
+namespace Flexi\Infrastructure\Factories;
 
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo;
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleType;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleDetectorInterface;
+use Flexi\Domain\ValueObjects\ModuleInfo;
+use Flexi\Domain\ValueObjects\ModuleType;
+use Flexi\Domain\Interfaces\ModuleDetectorInterface;
 
 /**
  * Module detector for locally installed modules.

--- a/src/Infrastructure/Factories/RouterFactory.php
+++ b/src/Infrastructure/Factories/RouterFactory.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Factories;
+namespace Flexi\Infrastructure\Factories;
 
-use CubaDevOps\Flexi\Domain\Interfaces\ConfigurationFilesProviderInterface;
-use CubaDevOps\Flexi\Infrastructure\DependencyInjection\RoutesDefinitionParser;
-use CubaDevOps\Flexi\Domain\ValueObjects\ConfigurationType;
+use Flexi\Domain\Interfaces\ConfigurationFilesProviderInterface;
+use Flexi\Infrastructure\DependencyInjection\RoutesDefinitionParser;
+use Flexi\Domain\ValueObjects\ConfigurationType;
 use Flexi\Contracts\Interfaces\EventBusInterface;
 use Flexi\Contracts\Interfaces\ObjectBuilderInterface;
-use CubaDevOps\Flexi\Infrastructure\Http\Router;
+use Flexi\Infrastructure\Http\Router;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 

--- a/src/Infrastructure/Factories/VendorModuleDetector.php
+++ b/src/Infrastructure/Factories/VendorModuleDetector.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Factories;
+namespace Flexi\Infrastructure\Factories;
 
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo;
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleType;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleCacheManagerInterface;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleDetectorInterface;
+use Flexi\Domain\ValueObjects\ModuleInfo;
+use Flexi\Domain\ValueObjects\ModuleType;
+use Flexi\Domain\Interfaces\ModuleCacheManagerInterface;
+use Flexi\Domain\Interfaces\ModuleDetectorInterface;
 use Flexi\Contracts\Interfaces\LoggerInterface;
 
 /**

--- a/src/Infrastructure/Http/Route.php
+++ b/src/Infrastructure/Http/Route.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Http;
+namespace Flexi\Infrastructure\Http;
 
 class Route
 {

--- a/src/Infrastructure/Http/Router.php
+++ b/src/Infrastructure/Http/Router.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Http;
+namespace Flexi\Infrastructure\Http;
 
 use Flexi\Contracts\Classes\ObjectCollection;
 use Flexi\Contracts\Classes\Traits\CacheKeyGeneratorTrait;
@@ -12,10 +12,10 @@ use Flexi\Contracts\Interfaces\CacheInterface;
 use Flexi\Contracts\Interfaces\CollectionInterface;
 use Flexi\Contracts\Interfaces\EventBusInterface;
 use Flexi\Contracts\Interfaces\ObjectBuilderInterface;
-use CubaDevOps\Flexi\Domain\Events\Event;
-use CubaDevOps\Flexi\Domain\Events\RouteNotFoundEvent;
+use Flexi\Domain\Events\Event;
+use Flexi\Domain\Events\RouteNotFoundEvent;
 use Flexi\Contracts\Classes\HttpHandler;
-use CubaDevOps\Flexi\Infrastructure\Http\Route;
+use Flexi\Infrastructure\Http\Route;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;

--- a/src/Infrastructure/Services/CommandExecutor.php
+++ b/src/Infrastructure/Services/CommandExecutor.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Services;
+namespace Flexi\Infrastructure\Services;
 
-use CubaDevOps\Flexi\Application\Services\CommandExecutorInterface;
+use Flexi\Application\Services\CommandExecutorInterface;
 
 /**
  * Service for executing system commands.

--- a/src/Infrastructure/Ui/Cli/CliInput.php
+++ b/src/Infrastructure/Ui/Cli/CliInput.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Ui\Cli;
+namespace Flexi\Infrastructure\Ui\Cli;
 
 class CliInput
 {

--- a/src/Infrastructure/Ui/Cli/CliInputParser.php
+++ b/src/Infrastructure/Ui/Cli/CliInputParser.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Ui\Cli;
+namespace Flexi\Infrastructure\Ui\Cli;
 
 class CliInputParser
 {

--- a/src/Infrastructure/Ui/Cli/CliType.php
+++ b/src/Infrastructure/Ui/Cli/CliType.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Ui\Cli;
+namespace Flexi\Infrastructure\Ui\Cli;
 
 class CliType
 {

--- a/src/Infrastructure/Ui/Cli/CommandHandler.php
+++ b/src/Infrastructure/Ui/Cli/CommandHandler.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Ui\Cli;
+namespace Flexi\Infrastructure\Ui\Cli;
 
-use CubaDevOps\Flexi\Domain\Commands\NotFoundCommand;
+use Flexi\Domain\Commands\NotFoundCommand;
 use Flexi\Contracts\Interfaces\CliDTOInterface;
 use Flexi\Contracts\Interfaces\BusInterface;
 use Flexi\Contracts\Interfaces\HandlerInterface;
 use Psr\Container\ContainerInterface;
-use CubaDevOps\Flexi\Infrastructure\Bus\CommandBus;
+use Flexi\Infrastructure\Bus\CommandBus;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 

--- a/src/Infrastructure/Ui/Cli/ConsoleApplication.php
+++ b/src/Infrastructure/Ui/Cli/ConsoleApplication.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Ui\Cli;
+namespace Flexi\Infrastructure\Ui\Cli;
 
-use CubaDevOps\Flexi\Infrastructure\Bus\CommandBus;
-use CubaDevOps\Flexi\Infrastructure\Bus\EventBus;
-use CubaDevOps\Flexi\Infrastructure\Bus\QueryBus;
-use CubaDevOps\Flexi\Infrastructure\Classes\Configuration;
-use CubaDevOps\Flexi\Infrastructure\Classes\ConfigurationRepository;
-use CubaDevOps\Flexi\Infrastructure\Factories\ContainerFactory;
+use Flexi\Infrastructure\Bus\CommandBus;
+use Flexi\Infrastructure\Bus\EventBus;
+use Flexi\Infrastructure\Bus\QueryBus;
+use Flexi\Infrastructure\Classes\Configuration;
+use Flexi\Infrastructure\Classes\ConfigurationRepository;
+use Flexi\Infrastructure\Factories\ContainerFactory;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use Symfony\Component\ErrorHandler\Debug;

--- a/src/Infrastructure/Ui/Cli/ConsoleExceptionFormatter.php
+++ b/src/Infrastructure/Ui/Cli/ConsoleExceptionFormatter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Ui\Cli;
+namespace Flexi\Infrastructure\Ui\Cli;
 
 use Throwable;
 

--- a/src/Infrastructure/Ui/Cli/ConsoleOutputFormatter.php
+++ b/src/Infrastructure/Ui/Cli/ConsoleOutputFormatter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Ui\Cli;
+namespace Flexi\Infrastructure\Ui\Cli;
 
 class ConsoleOutputFormatter
 {

--- a/src/Infrastructure/Ui/Cli/DTOFactory.php
+++ b/src/Infrastructure/Ui/Cli/DTOFactory.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Ui\Cli;
+namespace Flexi\Infrastructure\Ui\Cli;
 
 use Flexi\Contracts\Interfaces\BusInterface;
 use Flexi\Contracts\Interfaces\DTOInterface;
-use CubaDevOps\Flexi\Domain\Commands\NotFoundCommand;
+use Flexi\Domain\Commands\NotFoundCommand;
 
 class DTOFactory
 {

--- a/src/Infrastructure/Ui/Cli/EventHandler.php
+++ b/src/Infrastructure/Ui/Cli/EventHandler.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Ui\Cli;
+namespace Flexi\Infrastructure\Ui\Cli;
 
 use Flexi\Contracts\Interfaces\EventBusInterface;
-use CubaDevOps\Flexi\Domain\Events\Event;
+use Flexi\Domain\Events\Event;
 
 class EventHandler
 {

--- a/src/Infrastructure/Ui/Cli/QueryHandler.php
+++ b/src/Infrastructure/Ui/Cli/QueryHandler.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Ui\Cli;
+namespace Flexi\Infrastructure\Ui\Cli;
 
-use CubaDevOps\Flexi\Domain\Commands\NotFoundCommand;
+use Flexi\Domain\Commands\NotFoundCommand;
 use Flexi\Contracts\Interfaces\CliDTOInterface;
-use CubaDevOps\Flexi\Infrastructure\Bus\QueryBus;
+use Flexi\Infrastructure\Bus\QueryBus;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 

--- a/src/Infrastructure/Ui/Web/Application.php
+++ b/src/Infrastructure/Ui/Web/Application.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Ui\Web;
+namespace Flexi\Infrastructure\Ui\Web;
 
 use Flexi\Contracts\Interfaces\ConfigurationInterface;
-use CubaDevOps\Flexi\Infrastructure\Factories\RouterFactory;
-use CubaDevOps\Flexi\Infrastructure\Http\Router;
+use Flexi\Infrastructure\Factories\RouterFactory;
+use Flexi\Infrastructure\Http\Router;
 use GuzzleHttp\Psr7\ServerRequest;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;

--- a/tests/Application/Commands/ActivateModuleCommandTest.php
+++ b/tests/Application/Commands/ActivateModuleCommandTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Application\Commands;
+namespace Flexi\Test\Application\Commands;
 
-use CubaDevOps\Flexi\Application\Commands\ActivateModuleCommand;
+use Flexi\Application\Commands\ActivateModuleCommand;
 use Flexi\Contracts\Interfaces\DTOInterface;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Application/Commands/DeactivateModuleCommandTest.php
+++ b/tests/Application/Commands/DeactivateModuleCommandTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Application\Commands;
+namespace Flexi\Test\Application\Commands;
 
-use CubaDevOps\Flexi\Application\Commands\DeactivateModuleCommand;
+use Flexi\Application\Commands\DeactivateModuleCommand;
 use Flexi\Contracts\Interfaces\DTOInterface;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Application/Commands/ListModulesCommandTest.php
+++ b/tests/Application/Commands/ListModulesCommandTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Application\Commands;
+namespace Flexi\Test\Application\Commands;
 
-use CubaDevOps\Flexi\Application\Commands\ListModulesCommand;
+use Flexi\Application\Commands\ListModulesCommand;
 use Flexi\Contracts\Interfaces\CliDTOInterface;
 use Flexi\Contracts\Interfaces\DTOInterface;
 use PHPUnit\Framework\TestCase;

--- a/tests/Application/Commands/ModuleInfoCommandTest.php
+++ b/tests/Application/Commands/ModuleInfoCommandTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Application\Commands;
+namespace Flexi\Test\Application\Commands;
 
-use CubaDevOps\Flexi\Application\Commands\ModuleInfoCommand;
+use Flexi\Application\Commands\ModuleInfoCommand;
 use Flexi\Contracts\Interfaces\CliDTOInterface;
 use Flexi\Contracts\Interfaces\DTOInterface;
 use PHPUnit\Framework\TestCase;

--- a/tests/Application/Commands/ModuleStatusCommandTest.php
+++ b/tests/Application/Commands/ModuleStatusCommandTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Application\Commands;
+namespace Flexi\Test\Application\Commands;
 
-use CubaDevOps\Flexi\Application\Commands\ModuleStatusCommand;
+use Flexi\Application\Commands\ModuleStatusCommand;
 use Flexi\Contracts\Interfaces\CliDTOInterface;
 use Flexi\Contracts\Interfaces\DTOInterface;
 use PHPUnit\Framework\TestCase;

--- a/tests/Application/Commands/NotFoundCommandTest.php
+++ b/tests/Application/Commands/NotFoundCommandTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Application\Commands;
+namespace Flexi\Test\Application\Commands;
 
-use CubaDevOps\Flexi\Domain\Commands\NotFoundCommand;
+use Flexi\Domain\Commands\NotFoundCommand;
 use Flexi\Contracts\Interfaces\DTOInterface;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Application/Commands/UpdateModuleEnvironmentCommandTest.php
+++ b/tests/Application/Commands/UpdateModuleEnvironmentCommandTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Application\Commands;
+namespace Flexi\Test\Application\Commands;
 
-use CubaDevOps\Flexi\Application\Commands\UpdateModuleEnvironmentCommand;
+use Flexi\Application\Commands\UpdateModuleEnvironmentCommand;
 use Flexi\Contracts\Interfaces\DTOInterface;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Application/Commands/ValidateModulesCommandTest.php
+++ b/tests/Application/Commands/ValidateModulesCommandTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Application\Commands;
+namespace Flexi\Test\Application\Commands;
 
-use CubaDevOps\Flexi\Application\Commands\ValidateModulesCommand;
+use Flexi\Application\Commands\ValidateModulesCommand;
 use Flexi\Contracts\Interfaces\CliDTOInterface;
 use Flexi\Contracts\Interfaces\DTOInterface;
 use PHPUnit\Framework\TestCase;

--- a/tests/Application/UseCase/ActivateModuleTest.php
+++ b/tests/Application/UseCase/ActivateModuleTest.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Application\UseCase;
+namespace Flexi\Test\Application\UseCase;
 
-use CubaDevOps\Flexi\Application\Commands\ActivateModuleCommand;
-use CubaDevOps\Flexi\Application\UseCase\ActivateModule;
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo;
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleState;
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleType;
-use CubaDevOps\Flexi\Infrastructure\Factories\HybridModuleDetector;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleEnvironmentManagerInterface;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleStateManagerInterface;
+use Flexi\Application\Commands\ActivateModuleCommand;
+use Flexi\Application\UseCase\ActivateModule;
+use Flexi\Domain\ValueObjects\ModuleInfo;
+use Flexi\Domain\ValueObjects\ModuleState;
+use Flexi\Domain\ValueObjects\ModuleType;
+use Flexi\Infrastructure\Factories\HybridModuleDetector;
+use Flexi\Domain\Interfaces\ModuleEnvironmentManagerInterface;
+use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
 use DateTimeImmutable;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;

--- a/tests/Application/UseCase/DeactivateModuleTest.php
+++ b/tests/Application/UseCase/DeactivateModuleTest.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Application\UseCase;
+namespace Flexi\Test\Application\UseCase;
 
-use CubaDevOps\Flexi\Application\Commands\DeactivateModuleCommand;
-use CubaDevOps\Flexi\Application\UseCase\DeactivateModule;
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo;
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleState;
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleType;
-use CubaDevOps\Flexi\Infrastructure\Factories\HybridModuleDetector;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleEnvironmentManagerInterface;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleStateManagerInterface;
+use Flexi\Application\Commands\DeactivateModuleCommand;
+use Flexi\Application\UseCase\DeactivateModule;
+use Flexi\Domain\ValueObjects\ModuleInfo;
+use Flexi\Domain\ValueObjects\ModuleState;
+use Flexi\Domain\ValueObjects\ModuleType;
+use Flexi\Infrastructure\Factories\HybridModuleDetector;
+use Flexi\Domain\Interfaces\ModuleEnvironmentManagerInterface;
+use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
 use DateTimeImmutable;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;

--- a/tests/Application/UseCase/GetModuleInfoTest.php
+++ b/tests/Application/UseCase/GetModuleInfoTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Application\UseCase;
+namespace Flexi\Test\Application\UseCase;
 
-use CubaDevOps\Flexi\Application\Commands\ModuleInfoCommand;
-use CubaDevOps\Flexi\Application\UseCase\GetModuleInfo;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleStateManagerInterface;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleDetectorInterface;
+use Flexi\Application\Commands\ModuleInfoCommand;
+use Flexi\Application\UseCase\GetModuleInfo;
+use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
+use Flexi\Domain\Interfaces\ModuleDetectorInterface;
 use Flexi\Contracts\Classes\PlainTextMessage;
 use Flexi\Contracts\Interfaces\HandlerInterface;
 use Flexi\Contracts\Interfaces\MessageInterface;
@@ -106,10 +106,10 @@ class GetModuleInfoTest extends TestCase
         file_put_contents($modulePath . '/config.json', '{}');
 
         // Configure mock to return module info
-        $moduleInfo = new \CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo(
+        $moduleInfo = new \Flexi\Domain\ValueObjects\ModuleInfo(
             $moduleName,
             'cubadevops/flexi-module-test',
-            \CubaDevOps\Flexi\Domain\ValueObjects\ModuleType::local(),
+            \Flexi\Domain\ValueObjects\ModuleType::local(),
             $modulePath,
             '1.0.0',
             true,
@@ -137,7 +137,7 @@ class GetModuleInfoTest extends TestCase
             ->with($moduleName)
             ->willReturn(true);
 
-        $mockModuleState = $this->createMock(\CubaDevOps\Flexi\Domain\ValueObjects\ModuleState::class);
+        $mockModuleState = $this->createMock(\Flexi\Domain\ValueObjects\ModuleState::class);
         $this->stateManager->method('getModuleState')
             ->with($moduleName)
             ->willReturn($mockModuleState);
@@ -206,10 +206,10 @@ class GetModuleInfoTest extends TestCase
         );
 
         // Configure mock to return module info
-        $moduleInfo = new \CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo(
+        $moduleInfo = new \Flexi\Domain\ValueObjects\ModuleInfo(
             $moduleName,
             'cubadevops/flexi-module-minimal',
-            \CubaDevOps\Flexi\Domain\ValueObjects\ModuleType::local(),
+            \Flexi\Domain\ValueObjects\ModuleType::local(),
             $modulePath,
             'unknown',
             false,
@@ -285,10 +285,10 @@ class GetModuleInfoTest extends TestCase
         );
 
         // Configure mock to return module info
-        $moduleInfo = new \CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo(
+        $moduleInfo = new \Flexi\Domain\ValueObjects\ModuleInfo(
             $moduleName,
             'cubadevops/flexi-module-deep',
-            \CubaDevOps\Flexi\Domain\ValueObjects\ModuleType::local(),
+            \Flexi\Domain\ValueObjects\ModuleType::local(),
             $modulePath,
             '1.0.0',
             false,
@@ -334,10 +334,10 @@ class GetModuleInfoTest extends TestCase
         file_put_contents($modulePath . '/composer.json', 'invalid json content');
 
         // Configure mock to return module info
-        $moduleInfo = new \CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo(
+        $moduleInfo = new \Flexi\Domain\ValueObjects\ModuleInfo(
             $moduleName,
             'cubadevops/flexi-module-invalid',
-            \CubaDevOps\Flexi\Domain\ValueObjects\ModuleType::local(),
+            \Flexi\Domain\ValueObjects\ModuleType::local(),
             $modulePath,
             'unknown',
             false,

--- a/tests/Application/UseCase/GetModuleStatusTest.php
+++ b/tests/Application/UseCase/GetModuleStatusTest.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Application\UseCase;
+namespace Flexi\Test\Application\UseCase;
 
-use CubaDevOps\Flexi\Application\Commands\ModuleStatusCommand;
-use CubaDevOps\Flexi\Application\UseCase\GetModuleStatus;
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo;
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleState;
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleType;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleDetectorInterface;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleStateManagerInterface;
+use Flexi\Application\Commands\ModuleStatusCommand;
+use Flexi\Application\UseCase\GetModuleStatus;
+use Flexi\Domain\ValueObjects\ModuleInfo;
+use Flexi\Domain\ValueObjects\ModuleState;
+use Flexi\Domain\ValueObjects\ModuleType;
+use Flexi\Domain\Interfaces\ModuleDetectorInterface;
+use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
 use DateTimeImmutable;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;

--- a/tests/Application/UseCase/InstallModuleTest.backup
+++ b/tests/Application/UseCase/InstallModuleTest.backup
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Application\UseCase;
+namespace Flexi\Test\Application\UseCase;
 
-use CubaDevOps\Flexi\Application\Commands\InstallModuleCommand;
-use CubaDevOps\Flexi\Application\UseCase\InstallModule;
+use Flexi\Application\Commands\InstallModuleCommand;
+use Flexi\Application\UseCase\InstallModule;
 use Flexi\Contracts\Interfaces\HandlerInterface;
 use Flexi\Contracts\Interfaces\MessageInterface;
 use PHPUnit\Framework\TestCase;

--- a/tests/Application/UseCase/ListModulesTest.php
+++ b/tests/Application/UseCase/ListModulesTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Application\UseCase;
+namespace Flexi\Test\Application\UseCase;
 
-use CubaDevOps\Flexi\Application\Commands\ListModulesCommand;
-use CubaDevOps\Flexi\Application\UseCase\ListModules;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleStateManagerInterface;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleDetectorInterface;
+use Flexi\Application\Commands\ListModulesCommand;
+use Flexi\Application\UseCase\ListModules;
+use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
+use Flexi\Domain\Interfaces\ModuleDetectorInterface;
 use Flexi\Contracts\Classes\PlainTextMessage;
 use Flexi\Contracts\Interfaces\HandlerInterface;
 use Flexi\Contracts\Interfaces\MessageInterface;
@@ -98,10 +98,10 @@ class ListModulesTest extends TestCase
         );
 
         // Create ModuleInfo mock
-        $moduleInfo = new \CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo(
+        $moduleInfo = new \Flexi\Domain\ValueObjects\ModuleInfo(
             $moduleName,
             'cubadevops/flexi-module-test',
-            \CubaDevOps\Flexi\Domain\ValueObjects\ModuleType::local(),
+            \Flexi\Domain\ValueObjects\ModuleType::local(),
             $modulePath,
             '1.0.0',
             false,
@@ -169,10 +169,10 @@ class ListModulesTest extends TestCase
         mkdir($vendorModulePath);
 
         // Create ModuleInfo mock
-        $moduleInfo = new \CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo(
+        $moduleInfo = new \Flexi\Domain\ValueObjects\ModuleInfo(
             $moduleName,
             'cubadevops/flexi-module-auth',
-            \CubaDevOps\Flexi\Domain\ValueObjects\ModuleType::vendor(), // Vendor type for installed module
+            \Flexi\Domain\ValueObjects\ModuleType::vendor(), // Vendor type for installed module
             $modulePath,
             '2.0.0',
             false,
@@ -213,10 +213,10 @@ class ListModulesTest extends TestCase
         mkdir($modulePath);
 
         // Create ModuleInfo mock for broken module (no composer.json)
-        $moduleInfo = new \CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo(
+        $moduleInfo = new \Flexi\Domain\ValueObjects\ModuleInfo(
             $moduleName,
             'unknown',
-            \CubaDevOps\Flexi\Domain\ValueObjects\ModuleType::local(),
+            \Flexi\Domain\ValueObjects\ModuleType::local(),
             $modulePath,
             'unknown',
             false,
@@ -298,10 +298,10 @@ class ListModulesTest extends TestCase
         $moduleNames = ['Auth', 'Cache', 'Logging'];
 
         foreach ($moduleNames as $name) {
-            $modules[] = new \CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo(
+            $modules[] = new \Flexi\Domain\ValueObjects\ModuleInfo(
                 $name,
                 'cubadevops/flexi-module-' . strtolower($name),
-                \CubaDevOps\Flexi\Domain\ValueObjects\ModuleType::vendor(),
+                \Flexi\Domain\ValueObjects\ModuleType::vendor(),
                 '/vendor/cubadevops/flexi-module-' . strtolower($name),
                 '1.0.0',
                 false,
@@ -365,10 +365,10 @@ class ListModulesTest extends TestCase
         );
 
         // Create ModuleInfo mock for minimal module
-        $moduleInfo = new \CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo(
+        $moduleInfo = new \Flexi\Domain\ValueObjects\ModuleInfo(
             $moduleName,
             'cubadevops/flexi-module-minimal',
-            \CubaDevOps\Flexi\Domain\ValueObjects\ModuleType::local(),
+            \Flexi\Domain\ValueObjects\ModuleType::local(),
             $modulePath,
             'unknown',
             false,
@@ -416,10 +416,10 @@ class ListModulesTest extends TestCase
 
     public function testHandleIncludesConflictDetailsAndStatistics(): void
     {
-        $analytics = new \CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo(
+        $analytics = new \Flexi\Domain\ValueObjects\ModuleInfo(
             'analytics',
             'cubadevops/flexi-analytics',
-            \CubaDevOps\Flexi\Domain\ValueObjects\ModuleType::mixed(),
+            \Flexi\Domain\ValueObjects\ModuleType::mixed(),
             '/modules/analytics',
             '3.0.0',
             true,
@@ -444,10 +444,10 @@ class ListModulesTest extends TestCase
             ->method('getModuleStatistics')
             ->willReturn(['local_only' => 0, 'conflicts' => 1]);
 
-        $moduleState = new \CubaDevOps\Flexi\Domain\ValueObjects\ModuleState(
+        $moduleState = new \Flexi\Domain\ValueObjects\ModuleState(
             'analytics',
             false,
-            \CubaDevOps\Flexi\Domain\ValueObjects\ModuleType::mixed(),
+            \Flexi\Domain\ValueObjects\ModuleType::mixed(),
             new \DateTimeImmutable('2025-01-10T11:30:00+00:00'),
             'ops'
         );

--- a/tests/Application/UseCase/UpdateModuleEnvironmentTest.php
+++ b/tests/Application/UseCase/UpdateModuleEnvironmentTest.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Application\UseCase;
+namespace Flexi\Test\Application\UseCase;
 
-use CubaDevOps\Flexi\Application\Commands\UpdateModuleEnvironmentCommand;
-use CubaDevOps\Flexi\Application\UseCase\UpdateModuleEnvironment;
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo;
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleType;
-use CubaDevOps\Flexi\Infrastructure\Factories\HybridModuleDetector;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleEnvironmentManagerInterface;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleStateManagerInterface;
+use Flexi\Application\Commands\UpdateModuleEnvironmentCommand;
+use Flexi\Application\UseCase\UpdateModuleEnvironment;
+use Flexi\Domain\ValueObjects\ModuleInfo;
+use Flexi\Domain\ValueObjects\ModuleType;
+use Flexi\Infrastructure\Factories\HybridModuleDetector;
+use Flexi\Domain\Interfaces\ModuleEnvironmentManagerInterface;
+use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Application/UseCase/ValidateModulesTest.php
+++ b/tests/Application/UseCase/ValidateModulesTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Application\UseCase;
+namespace Flexi\Test\Application\UseCase;
 
-use CubaDevOps\Flexi\Application\Commands\ValidateModulesCommand;
-use CubaDevOps\Flexi\Application\UseCase\ValidateModules;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleStateManagerInterface;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleDetectorInterface;
+use Flexi\Application\Commands\ValidateModulesCommand;
+use Flexi\Application\UseCase\ValidateModules;
+use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
+use Flexi\Domain\Interfaces\ModuleDetectorInterface;
 use Flexi\Contracts\Interfaces\HandlerInterface;
 use Flexi\Contracts\Interfaces\MessageInterface;
 use PHPUnit\Framework\TestCase;
@@ -92,7 +92,7 @@ class ValidateModulesTest extends TestCase
             ],
             'autoload' => [
                 'psr-4' => [
-                    "CubaDevOps\\Flexi\\Modules\\{$moduleName}\\" => '/'
+                    "Flexi\\Modules\\{$moduleName}\\" => '/'
                 ]
             ],
             'extra' => [
@@ -153,7 +153,7 @@ class ValidateModulesTest extends TestCase
             } else {
                 $composerData['autoload'] = [
                     'psr-4' => [
-                        "CubaDevOps\\Flexi\\Modules\\{$moduleName}\\" => '/'
+                        "Flexi\\Modules\\{$moduleName}\\" => '/'
                     ]
                 ];
             }
@@ -258,19 +258,19 @@ class ValidateModulesTest extends TestCase
 
         // Create ModuleInfo objects for the modules
         $modules = [
-            new \CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo(
+            new \Flexi\Domain\ValueObjects\ModuleInfo(
                 'testmodule1',
                 'cubadevops/flexi-module-testmodule1',
-                \CubaDevOps\Flexi\Domain\ValueObjects\ModuleType::local(),
+                \Flexi\Domain\ValueObjects\ModuleType::local(),
                 $this->tempModulesPath . '/testmodule1',
                 '1.0.0',
                 false,
                 []
             ),
-            new \CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo(
+            new \Flexi\Domain\ValueObjects\ModuleInfo(
                 'testmodule2',
                 'cubadevops/flexi-module-testmodule2',
-                \CubaDevOps\Flexi\Domain\ValueObjects\ModuleType::local(),
+                \Flexi\Domain\ValueObjects\ModuleType::local(),
                 $this->tempModulesPath . '/testmodule2',
                 '1.0.0',
                 false,
@@ -305,10 +305,10 @@ class ValidateModulesTest extends TestCase
         $this->createInvalidModule('badmodule', ['no_composer_json']);
 
         // Create ModuleInfo object for the module
-        $moduleInfo = new \CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo(
+        $moduleInfo = new \Flexi\Domain\ValueObjects\ModuleInfo(
             'badmodule',
             'cubadevops/flexi-module-badmodule',
-            \CubaDevOps\Flexi\Domain\ValueObjects\ModuleType::local(),
+            \Flexi\Domain\ValueObjects\ModuleType::local(),
             $this->tempModulesPath . '/badmodule',
             '1.0.0',
             false,
@@ -341,10 +341,10 @@ class ValidateModulesTest extends TestCase
         $this->createInvalidModule('invalidjson', ['invalid_json']);
 
         // Create ModuleInfo object for the module
-        $moduleInfo = new \CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo(
+        $moduleInfo = new \Flexi\Domain\ValueObjects\ModuleInfo(
             'invalidjson',
             'cubadevops/flexi-module-invalidjson',
-            \CubaDevOps\Flexi\Domain\ValueObjects\ModuleType::local(),
+            \Flexi\Domain\ValueObjects\ModuleType::local(),
             $this->tempModulesPath . '/invalidjson',
             '1.0.0',
             false,
@@ -378,10 +378,10 @@ class ValidateModulesTest extends TestCase
         $this->createInvalidModule('incomplete', ['missing_name', 'missing_version', 'missing_type', 'missing_autoload']);
 
         // Create ModuleInfo object for the module
-        $moduleInfo = new \CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo(
+        $moduleInfo = new \Flexi\Domain\ValueObjects\ModuleInfo(
             'incomplete',
             'cubadevops/flexi-module-incomplete',
-            \CubaDevOps\Flexi\Domain\ValueObjects\ModuleType::local(),
+            \Flexi\Domain\ValueObjects\ModuleType::local(),
             $this->tempModulesPath . '/incomplete',
             '1.0.0',
             false,
@@ -424,10 +424,10 @@ class ValidateModulesTest extends TestCase
         $this->createInvalidModule('nodep', ['missing_flexi_dependency']);
 
         // Create ModuleInfo object for the module
-        $moduleInfo = new \CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo(
+        $moduleInfo = new \Flexi\Domain\ValueObjects\ModuleInfo(
             'nodep',
             'cubadevops/flexi-module-nodep',
-            \CubaDevOps\Flexi\Domain\ValueObjects\ModuleType::local(),
+            \Flexi\Domain\ValueObjects\ModuleType::local(),
             $this->tempModulesPath . '/nodep',
             '1.0.0',
             false,
@@ -464,10 +464,10 @@ class ValidateModulesTest extends TestCase
         ]);
 
         // Create ModuleInfo object for the module
-        $moduleInfo = new \CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo(
+        $moduleInfo = new \Flexi\Domain\ValueObjects\ModuleInfo(
             'warnings',
             'cubadevops/flexi-module-warnings',
-            \CubaDevOps\Flexi\Domain\ValueObjects\ModuleType::local(),
+            \Flexi\Domain\ValueObjects\ModuleType::local(),
             $this->tempModulesPath . '/warnings',
             '1.0.0',
             false,
@@ -513,10 +513,10 @@ class ValidateModulesTest extends TestCase
         ]);
 
         // Create ModuleInfo object for the module
-        $moduleInfo = new \CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo(
+        $moduleInfo = new \Flexi\Domain\ValueObjects\ModuleInfo(
             'metawarn',
             'cubadevops/flexi-module-metawarn',
-            \CubaDevOps\Flexi\Domain\ValueObjects\ModuleType::local(),
+            \Flexi\Domain\ValueObjects\ModuleType::local(),
             $this->tempModulesPath . '/metawarn',
             '1.0.0',
             false,
@@ -560,7 +560,7 @@ class ValidateModulesTest extends TestCase
             'require' => ['cubadevops/flexi-contracts' => '*'],
             'autoload' => [
                 'psr-4' => [
-                    'CubaDevOps\\Flexi\\Modules\\nometa\\' => '/'
+                    'Flexi\\Modules\\nometa\\' => '/'
                 ]
             ]
             // Missing 'extra' section
@@ -569,10 +569,10 @@ class ValidateModulesTest extends TestCase
         file_put_contents($moduleDir . '/composer.json', json_encode($composerData, JSON_PRETTY_PRINT));
 
         // Create ModuleInfo object for the module
-        $moduleInfo = new \CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo(
+        $moduleInfo = new \Flexi\Domain\ValueObjects\ModuleInfo(
             'nometa',
             'cubadevops/flexi-module-nometa',
-            \CubaDevOps\Flexi\Domain\ValueObjects\ModuleType::local(),
+            \Flexi\Domain\ValueObjects\ModuleType::local(),
             $moduleDir,
             '1.0.0',
             false,
@@ -608,7 +608,7 @@ class ValidateModulesTest extends TestCase
             'require' => ['cubadevops/flexi-contracts' => '*'],
             'autoload' => [
                 'psr-4' => [
-                    'CubaDevOps\\Flexi\\Modules\\nodirs\\' => '/'
+                    'Flexi\\Modules\\nodirs\\' => '/'
                 ]
             ]
         ];
@@ -616,10 +616,10 @@ class ValidateModulesTest extends TestCase
         file_put_contents($moduleDir . '/composer.json', json_encode($composerData, JSON_PRETTY_PRINT));
 
         // Create ModuleInfo object for the test module
-        $moduleInfo = new \CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo(
+        $moduleInfo = new \Flexi\Domain\ValueObjects\ModuleInfo(
             'nodirs',
             'cubadevops/flexi-module-nodirs',
-            \CubaDevOps\Flexi\Domain\ValueObjects\ModuleType::local(),
+            \Flexi\Domain\ValueObjects\ModuleType::local(),
             $moduleDir,
             '1.0.0',
             false,
@@ -663,10 +663,10 @@ class ValidateModulesTest extends TestCase
             'resolution_strategy' => 'local_priority',
         ];
 
-        $moduleInfo = new \CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo(
+        $moduleInfo = new \Flexi\Domain\ValueObjects\ModuleInfo(
             'hybrid',
             'cubadevops/flexi-module-hybrid',
-            \CubaDevOps\Flexi\Domain\ValueObjects\ModuleType::mixed(),
+            \Flexi\Domain\ValueObjects\ModuleType::mixed(),
             $this->tempModulesPath . '/hybrid',
             '1.0.0',
             true,
@@ -675,10 +675,10 @@ class ValidateModulesTest extends TestCase
 
         $this->moduleDetector->method('getAllModules')->willReturn([$moduleInfo]);
 
-        $moduleState = new \CubaDevOps\Flexi\Domain\ValueObjects\ModuleState(
+        $moduleState = new \Flexi\Domain\ValueObjects\ModuleState(
             'hybrid',
             true,
-            \CubaDevOps\Flexi\Domain\ValueObjects\ModuleType::mixed(),
+            \Flexi\Domain\ValueObjects\ModuleType::mixed(),
             new \DateTimeImmutable('2025-01-15T09:45:00+00:00'),
             'platform'
         );
@@ -721,37 +721,37 @@ class ValidateModulesTest extends TestCase
 
         // Create ModuleInfo objects for all modules
         $modules = [
-            new \CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo(
+            new \Flexi\Domain\ValueObjects\ModuleInfo(
                 'good1',
                 'cubadevops/flexi-module-good1',
-                \CubaDevOps\Flexi\Domain\ValueObjects\ModuleType::local(),
+                \Flexi\Domain\ValueObjects\ModuleType::local(),
                 $this->tempModulesPath . '/good1',
                 '1.0.0',
                 false,
                 []
             ),
-            new \CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo(
+            new \Flexi\Domain\ValueObjects\ModuleInfo(
                 'bad1',
                 'cubadevops/flexi-module-bad1',
-                \CubaDevOps\Flexi\Domain\ValueObjects\ModuleType::local(),
+                \Flexi\Domain\ValueObjects\ModuleType::local(),
                 $this->tempModulesPath . '/bad1',
                 '1.0.0',
                 false,
                 []
             ),
-            new \CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo(
+            new \Flexi\Domain\ValueObjects\ModuleInfo(
                 'bad2',
                 'cubadevops/flexi-module-bad2',
-                \CubaDevOps\Flexi\Domain\ValueObjects\ModuleType::local(),
+                \Flexi\Domain\ValueObjects\ModuleType::local(),
                 $this->tempModulesPath . '/bad2',
                 '1.0.0',
                 false,
                 []
             ),
-            new \CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo(
+            new \Flexi\Domain\ValueObjects\ModuleInfo(
                 'good2',
                 'cubadevops/flexi-module-good2',
-                \CubaDevOps\Flexi\Domain\ValueObjects\ModuleType::local(),
+                \Flexi\Domain\ValueObjects\ModuleType::local(),
                 $this->tempModulesPath . '/good2',
                 '1.0.0',
                 false,

--- a/tests/Domain/Events/EventTest.php
+++ b/tests/Domain/Events/EventTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Domain\Events;
+namespace Flexi\Test\Domain\Events;
 
-use CubaDevOps\Flexi\Domain\Events\Event;
+use Flexi\Domain\Events\Event;
 use PHPUnit\Framework\TestCase;
 
 class EventTest extends TestCase

--- a/tests/Domain/Events/RouteNotFoundEventTest.php
+++ b/tests/Domain/Events/RouteNotFoundEventTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Domain\Events;
+namespace Flexi\Test\Domain\Events;
 
-use CubaDevOps\Flexi\Domain\Events\RouteNotFoundEvent;
+use Flexi\Domain\Events\RouteNotFoundEvent;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;

--- a/tests/Domain/Exceptions/ContainerExceptionTest.php
+++ b/tests/Domain/Exceptions/ContainerExceptionTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Domain\Exceptions;
+namespace Flexi\Test\Domain\Exceptions;
 
-use CubaDevOps\Flexi\Domain\Exceptions\ContainerException;
+use Flexi\Domain\Exceptions\ContainerException;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\NotFoundExceptionInterface;
 

--- a/tests/Domain/Exceptions/InvalidArgumentCacheExceptionTest.php
+++ b/tests/Domain/Exceptions/InvalidArgumentCacheExceptionTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Domain\Exceptions;
+namespace Flexi\Test\Domain\Exceptions;
 
-use CubaDevOps\Flexi\Domain\Exceptions\InvalidArgumentCacheException;
+use Flexi\Domain\Exceptions\InvalidArgumentCacheException;
 use PHPUnit\Framework\TestCase;
 use Psr\SimpleCache\InvalidArgumentException;
 

--- a/tests/Domain/Exceptions/ServiceNotFoundExceptionTest.php
+++ b/tests/Domain/Exceptions/ServiceNotFoundExceptionTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Domain\Exceptions;
+namespace Flexi\Test\Domain\Exceptions;
 
-use CubaDevOps\Flexi\Domain\Exceptions\ServiceNotFoundException;
+use Flexi\Domain\Exceptions\ServiceNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\NotFoundExceptionInterface;
 

--- a/tests/Domain/ValueObjects/ConfigurationTypeTest.php
+++ b/tests/Domain/ValueObjects/ConfigurationTypeTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Tests\Domain\ValueObjects;
+namespace Flexi\Tests\Domain\ValueObjects;
 
-use CubaDevOps\Flexi\Domain\ValueObjects\ConfigurationType;
+use Flexi\Domain\ValueObjects\ConfigurationType;
 use PHPUnit\Framework\TestCase;
 
 class ConfigurationTypeTest extends TestCase

--- a/tests/Domain/ValueObjects/ModuleInfoTest.php
+++ b/tests/Domain/ValueObjects/ModuleInfoTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Domain\ValueObjects;
+namespace Flexi\Test\Domain\ValueObjects;
 
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo;
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleType;
+use Flexi\Domain\ValueObjects\ModuleInfo;
+use Flexi\Domain\ValueObjects\ModuleType;
 use PHPUnit\Framework\TestCase;
 
 class ModuleInfoTest extends TestCase

--- a/tests/Domain/ValueObjects/ModuleStateTest.php
+++ b/tests/Domain/ValueObjects/ModuleStateTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Domain\ValueObjects;
+namespace Flexi\Test\Domain\ValueObjects;
 
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleState;
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleType;
+use Flexi\Domain\ValueObjects\ModuleState;
+use Flexi\Domain\ValueObjects\ModuleType;
 use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Domain/ValueObjects/ModuleTypeTest.php
+++ b/tests/Domain/ValueObjects/ModuleTypeTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Domain\ValueObjects;
+namespace Flexi\Test\Domain\ValueObjects;
 
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleType;
+use Flexi\Domain\ValueObjects\ModuleType;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;

--- a/tests/Domain/ValueObjects/ServiceTypeTest.php
+++ b/tests/Domain/ValueObjects/ServiceTypeTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Domain\ValueObjects;
+namespace Flexi\Test\Domain\ValueObjects;
 
-use CubaDevOps\Flexi\Domain\ValueObjects\ServiceType;
+use Flexi\Domain\ValueObjects\ServiceType;
 use Flexi\Contracts\Interfaces\ValueObjectInterface;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;

--- a/tests/Examples/TestEnvironmentUsageExampleTest.php
+++ b/tests/Examples/TestEnvironmentUsageExampleTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Examples;
+namespace Flexi\Test\Examples;
 
-use CubaDevOps\Flexi\Infrastructure\Classes\ConfigurationRepository;
+use Flexi\Infrastructure\Classes\ConfigurationRepository;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Infrastructure/Bus/CommandBusTest.php
+++ b/tests/Infrastructure/Bus/CommandBusTest.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\Bus;
+namespace Flexi\Test\Infrastructure\Bus;
 
 use Flexi\Contracts\Classes\PlainTextMessage;
 use Flexi\Contracts\Interfaces\EventBusInterface;
 use Flexi\Contracts\Interfaces\ObjectBuilderInterface;
-use CubaDevOps\Flexi\Domain\Commands\NotFoundCommand;
-use CubaDevOps\Flexi\Test\TestData\Commands\TestCommand;
-use CubaDevOps\Flexi\Test\TestData\Handlers\TestCommandHandler;
-use CubaDevOps\Flexi\Infrastructure\Bus\CommandBus;
+use Flexi\Domain\Commands\NotFoundCommand;
+use Flexi\Test\TestData\Commands\TestCommand;
+use Flexi\Test\TestData\Handlers\TestCommandHandler;
+use Flexi\Infrastructure\Bus\CommandBus;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerExceptionInterface;
@@ -137,7 +137,7 @@ class CommandBusTest extends TestCase
         try {
             $dtoClass = $this->commandBus->getDtoClassFromAlias('non-existent-alias');
             // If it somehow returns, we test the fallback
-            $this->assertEquals(\CubaDevOps\Flexi\Domain\Commands\NotFoundCommand::class, $dtoClass);
+            $this->assertEquals(\Flexi\Domain\Commands\NotFoundCommand::class, $dtoClass);
         } catch (\Error $e) {
             // If it throws an error, that's also valid behavior to test
             $this->assertStringContainsString('non-existent-alias', $e->getMessage());

--- a/tests/Infrastructure/Bus/EventBusTest.php
+++ b/tests/Infrastructure/Bus/EventBusTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Infrastructure\Bus;
+namespace Flexi\Infrastructure\Bus;
 
 final class EventBusTestOverrides
 {
@@ -62,15 +62,15 @@ function fclose($resource): bool
     return true;
 }
 
-namespace CubaDevOps\Flexi\Tests\Infrastructure\Bus;
+namespace Flexi\Tests\Infrastructure\Bus;
 
-use CubaDevOps\Flexi\Domain\Commands\NotFoundCommand;
-use CubaDevOps\Flexi\Infrastructure\Bus\EventBus;
-use CubaDevOps\Flexi\Infrastructure\Bus\EventBusTestOverrides;
-use CubaDevOps\Flexi\Test\TestData\TestDoubles\Bus\GenericMessage;
-use CubaDevOps\Flexi\Test\TestData\TestDoubles\Bus\RecordingListener;
-use CubaDevOps\Flexi\Test\TestData\TestDoubles\Bus\SampleEvent;
-use CubaDevOps\Flexi\Test\TestData\TestDoubles\Bus\SecondaryListener;
+use Flexi\Domain\Commands\NotFoundCommand;
+use Flexi\Infrastructure\Bus\EventBus;
+use Flexi\Infrastructure\Bus\EventBusTestOverrides;
+use Flexi\Test\TestData\TestDoubles\Bus\GenericMessage;
+use Flexi\Test\TestData\TestDoubles\Bus\RecordingListener;
+use Flexi\Test\TestData\TestDoubles\Bus\SampleEvent;
+use Flexi\Test\TestData\TestDoubles\Bus\SecondaryListener;
 use Flexi\Contracts\Interfaces\ConfigurationRepositoryInterface;
 use Flexi\Contracts\Interfaces\EventInterface;
 use Flexi\Contracts\Interfaces\ObjectBuilderInterface;

--- a/tests/Infrastructure/Bus/QueryBusTest.php
+++ b/tests/Infrastructure/Bus/QueryBusTest.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\Bus;
+namespace Flexi\Test\Infrastructure\Bus;
 
 use Flexi\Contracts\Classes\PlainTextMessage;
 use Flexi\Contracts\Interfaces\EventBusInterface;
 use Flexi\Contracts\Interfaces\ObjectBuilderInterface;
-use CubaDevOps\Flexi\Domain\Commands\NotFoundCommand;
-use CubaDevOps\Flexi\Test\TestData\Queries\TestQuery;
-use CubaDevOps\Flexi\Test\TestData\Handlers\TestQueryHandler;
-use CubaDevOps\Flexi\Infrastructure\Bus\QueryBus;
+use Flexi\Domain\Commands\NotFoundCommand;
+use Flexi\Test\TestData\Queries\TestQuery;
+use Flexi\Test\TestData\Handlers\TestQueryHandler;
+use Flexi\Infrastructure\Bus\QueryBus;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;

--- a/tests/Infrastructure/Classes/ConfigurationFilesProviderTest.php
+++ b/tests/Infrastructure/Classes/ConfigurationFilesProviderTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Tests\Infrastructure\Classes;
+namespace Flexi\Tests\Infrastructure\Classes;
 
-use CubaDevOps\Flexi\Domain\ValueObjects\ConfigurationType;
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo;
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleType;
-use CubaDevOps\Flexi\Infrastructure\Classes\ConfigurationFilesProvider;
-use CubaDevOps\Flexi\Infrastructure\Factories\HybridModuleDetector;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleStateManagerInterface;
+use Flexi\Domain\ValueObjects\ConfigurationType;
+use Flexi\Domain\ValueObjects\ModuleInfo;
+use Flexi\Domain\ValueObjects\ModuleType;
+use Flexi\Infrastructure\Classes\ConfigurationFilesProvider;
+use Flexi\Infrastructure\Factories\HybridModuleDetector;
+use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Infrastructure/Classes/ConfigurationRepositoryTest.php
+++ b/tests/Infrastructure/Classes/ConfigurationRepositoryTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Tests\Infrastructure\Classes;
+namespace Flexi\Tests\Infrastructure\Classes;
 
-use CubaDevOps\Flexi\Infrastructure\Classes\ConfigurationRepository;
+use Flexi\Infrastructure\Classes\ConfigurationRepository;
 use PHPUnit\Framework\TestCase;
 
 class ConfigurationRepositoryTest extends TestCase

--- a/tests/Infrastructure/Classes/ConfigurationTest.php
+++ b/tests/Infrastructure/Classes/ConfigurationTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\Classes;
+namespace Flexi\Test\Infrastructure\Classes;
 
-use CubaDevOps\Flexi\Infrastructure\Classes\Configuration;
+use Flexi\Infrastructure\Classes\Configuration;
 use Flexi\Contracts\Interfaces\ConfigurationRepositoryInterface;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Infrastructure/Classes/InMemoryCacheTest.php
+++ b/tests/Infrastructure/Classes/InMemoryCacheTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\Classes;
+namespace Flexi\Test\Infrastructure\Classes;
 
-use CubaDevOps\Flexi\Domain\Exceptions\InvalidArgumentCacheException;
-use CubaDevOps\Flexi\Infrastructure\Classes\InMemoryCache;
+use Flexi\Domain\Exceptions\InvalidArgumentCacheException;
+use Flexi\Infrastructure\Classes\InMemoryCache;
 use Flexi\Contracts\Interfaces\CacheInterface;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Infrastructure/Classes/ModuleCacheManagerTest.php
+++ b/tests/Infrastructure/Classes/ModuleCacheManagerTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\Classes;
+namespace Flexi\Test\Infrastructure\Classes;
 
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo;
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleType;
-use CubaDevOps\Flexi\Infrastructure\Classes\ModuleCacheManager;
+use Flexi\Domain\ValueObjects\ModuleInfo;
+use Flexi\Domain\ValueObjects\ModuleType;
+use Flexi\Infrastructure\Classes\ModuleCacheManager;
 use PHPUnit\Framework\TestCase;
 
 final class ModuleCacheManagerTest extends TestCase

--- a/tests/Infrastructure/Classes/ModuleEnvironmentManagerTest.php
+++ b/tests/Infrastructure/Classes/ModuleEnvironmentManagerTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Tests\Infrastructure\Classes;
+namespace Flexi\Tests\Infrastructure\Classes;
 
-use CubaDevOps\Flexi\Infrastructure\Classes\ModuleEnvironmentManager;
-use CubaDevOps\Flexi\Test\TestData\TestDoubles\Configuration\ArrayConfiguration;
-use CubaDevOps\Flexi\Test\TestData\TestDoubles\Modules\ModuleEnvironmentManagerAlwaysHas;
-use CubaDevOps\Flexi\Test\TestData\TestDoubles\Modules\ModuleEnvironmentManagerRemovalFails;
+use Flexi\Infrastructure\Classes\ModuleEnvironmentManager;
+use Flexi\Test\TestData\TestDoubles\Configuration\ArrayConfiguration;
+use Flexi\Test\TestData\TestDoubles\Modules\ModuleEnvironmentManagerAlwaysHas;
+use Flexi\Test\TestData\TestDoubles\Modules\ModuleEnvironmentManagerRemovalFails;
 use PHPUnit\Framework\TestCase;
 
 class ModuleEnvironmentManagerTest extends TestCase

--- a/tests/Infrastructure/Classes/ModuleStateManagerTest.php
+++ b/tests/Infrastructure/Classes/ModuleStateManagerTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\Classes;
+namespace Flexi\Test\Infrastructure\Classes;
 
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo;
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleState;
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleType;
-use CubaDevOps\Flexi\Infrastructure\Classes\ModuleStateManager;
-use CubaDevOps\Flexi\Infrastructure\Classes\ModuleStateRepository;
+use Flexi\Domain\ValueObjects\ModuleInfo;
+use Flexi\Domain\ValueObjects\ModuleState;
+use Flexi\Domain\ValueObjects\ModuleType;
+use Flexi\Infrastructure\Classes\ModuleStateManager;
+use Flexi\Infrastructure\Classes\ModuleStateRepository;
 use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Infrastructure/Classes/ModuleStateRepositoryTest.php
+++ b/tests/Infrastructure/Classes/ModuleStateRepositoryTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\Classes;
+namespace Flexi\Test\Infrastructure\Classes;
 
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleState;
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleType;
-use CubaDevOps\Flexi\Infrastructure\Classes\ModuleStateRepository;
+use Flexi\Domain\ValueObjects\ModuleState;
+use Flexi\Domain\ValueObjects\ModuleType;
+use Flexi\Infrastructure\Classes\ModuleStateRepository;
 use PHPUnit\Framework\TestCase;
 
 final class ModuleStateRepositoryTest extends TestCase

--- a/tests/Infrastructure/Classes/ObjectBuilderTest.php
+++ b/tests/Infrastructure/Classes/ObjectBuilderTest.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\Classes;
+namespace Flexi\Test\Infrastructure\Classes;
 
-use CubaDevOps\Flexi\Infrastructure\Classes\Configuration;
-use CubaDevOps\Flexi\Infrastructure\Classes\ObjectBuilder;
-use CubaDevOps\Flexi\Infrastructure\Classes\InMemoryCache;
-use CubaDevOps\Flexi\Infrastructure\Factories\ContainerFactory;
-use CubaDevOps\Flexi\Test\TestData\TestDoubles\HasNoConstructor;
-use CubaDevOps\Flexi\Test\TestData\TestDoubles\HasUnresolvableParameter;
-use CubaDevOps\Flexi\Test\TestData\TestDoubles\IsNotInstantiable;
-use CubaDevOps\Flexi\Test\TestData\TestDoubles\HasUnresolvableDependency;
+use Flexi\Infrastructure\Classes\Configuration;
+use Flexi\Infrastructure\Classes\ObjectBuilder;
+use Flexi\Infrastructure\Classes\InMemoryCache;
+use Flexi\Infrastructure\Factories\ContainerFactory;
+use Flexi\Test\TestData\TestDoubles\HasNoConstructor;
+use Flexi\Test\TestData\TestDoubles\HasUnresolvableParameter;
+use Flexi\Test\TestData\TestDoubles\IsNotInstantiable;
+use Flexi\Test\TestData\TestDoubles\HasUnresolvableDependency;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 

--- a/tests/Infrastructure/DependencyInjection/ConfigurationParsersTest.php
+++ b/tests/Infrastructure/DependencyInjection/ConfigurationParsersTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Tests\Infrastructure\DependencyInjection;
+namespace Flexi\Tests\Infrastructure\DependencyInjection;
 
-use CubaDevOps\Flexi\Infrastructure\DependencyInjection\RoutesDefinitionParser;
-use CubaDevOps\Flexi\Infrastructure\DependencyInjection\HandlersDefinitionParser;
-use CubaDevOps\Flexi\Infrastructure\DependencyInjection\ListenersDefinitionParser;
-use CubaDevOps\Flexi\Infrastructure\Classes\InMemoryCache;
+use Flexi\Infrastructure\DependencyInjection\RoutesDefinitionParser;
+use Flexi\Infrastructure\DependencyInjection\HandlersDefinitionParser;
+use Flexi\Infrastructure\DependencyInjection\ListenersDefinitionParser;
+use Flexi\Infrastructure\Classes\InMemoryCache;
 use PHPUnit\Framework\TestCase;
 
 class ConfigurationParsersTest extends TestCase

--- a/tests/Infrastructure/DependencyInjection/ContainerTest.php
+++ b/tests/Infrastructure/DependencyInjection/ContainerTest.php
@@ -2,22 +2,22 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\DependencyInjection;
+namespace Flexi\Test\Infrastructure\DependencyInjection;
 
 use Flexi\Contracts\Interfaces\CacheInterface;
 use Flexi\Contracts\Interfaces\ConfigurationInterface;
 use Flexi\Contracts\Interfaces\ObjectBuilderInterface;
-use CubaDevOps\Flexi\Infrastructure\DependencyInjection\Service;
-use CubaDevOps\Flexi\Infrastructure\DependencyInjection\ServiceClassDefinition;
-use CubaDevOps\Flexi\Domain\Exceptions\ServiceNotFoundException;
-use CubaDevOps\Flexi\Domain\ValueObjects\ServiceType;
-use CubaDevOps\Flexi\Infrastructure\Bus\CommandBus;
-use CubaDevOps\Flexi\Infrastructure\Bus\EventBus;
-use CubaDevOps\Flexi\Infrastructure\Bus\QueryBus;
-use CubaDevOps\Flexi\Infrastructure\Classes\Configuration;
-use CubaDevOps\Flexi\Infrastructure\DependencyInjection\Container;
-use CubaDevOps\Flexi\Infrastructure\Factories\ContainerFactory;
-use CubaDevOps\Flexi\Test\TestData\TestDoubles\DummyCache;
+use Flexi\Infrastructure\DependencyInjection\Service;
+use Flexi\Infrastructure\DependencyInjection\ServiceClassDefinition;
+use Flexi\Domain\Exceptions\ServiceNotFoundException;
+use Flexi\Domain\ValueObjects\ServiceType;
+use Flexi\Infrastructure\Bus\CommandBus;
+use Flexi\Infrastructure\Bus\EventBus;
+use Flexi\Infrastructure\Bus\QueryBus;
+use Flexi\Infrastructure\Classes\Configuration;
+use Flexi\Infrastructure\DependencyInjection\Container;
+use Flexi\Infrastructure\Factories\ContainerFactory;
+use Flexi\Test\TestData\TestDoubles\DummyCache;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
@@ -203,7 +203,7 @@ class ContainerTest extends TestCase
         $property->setValue($this->container, $definitions);
 
         // The actual exception thrown is ServiceNotFoundException
-        $this->expectException(\CubaDevOps\Flexi\Domain\Exceptions\ServiceNotFoundException::class);
+        $this->expectException(\Flexi\Domain\Exceptions\ServiceNotFoundException::class);
         $this->container->get('invalid_alias');
     }
 

--- a/tests/Infrastructure/DependencyInjection/ListenersDefinitionParserTest.php
+++ b/tests/Infrastructure/DependencyInjection/ListenersDefinitionParserTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\DependencyInjection;
+namespace Flexi\Test\Infrastructure\DependencyInjection;
 
-use CubaDevOps\Flexi\Infrastructure\DependencyInjection\ListenersDefinitionParser;
+use Flexi\Infrastructure\DependencyInjection\ListenersDefinitionParser;
 use Flexi\Contracts\Interfaces\CacheInterface;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Infrastructure/DependencyInjection/RoutesDefinitionParserTest.php
+++ b/tests/Infrastructure/DependencyInjection/RoutesDefinitionParserTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\DependencyInjection;
+namespace Flexi\Test\Infrastructure\DependencyInjection;
 
-use CubaDevOps\Flexi\Infrastructure\DependencyInjection\RoutesDefinitionParser;
-use CubaDevOps\Flexi\Infrastructure\Http\Route;
+use Flexi\Infrastructure\DependencyInjection\RoutesDefinitionParser;
+use Flexi\Infrastructure\Http\Route;
 use Flexi\Contracts\Interfaces\CacheInterface;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Infrastructure/DependencyInjection/ServiceClassDefinitionTest.php
+++ b/tests/Infrastructure/DependencyInjection/ServiceClassDefinitionTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\DependencyInjection;
+namespace Flexi\Test\Infrastructure\DependencyInjection;
 
-use CubaDevOps\Flexi\Infrastructure\DependencyInjection\ServiceClassDefinition;
+use Flexi\Infrastructure\DependencyInjection\ServiceClassDefinition;
 use PHPUnit\Framework\TestCase;
 
 class ServiceClassDefinitionTest extends TestCase

--- a/tests/Infrastructure/DependencyInjection/ServiceFactoryDefinitionTest.php
+++ b/tests/Infrastructure/DependencyInjection/ServiceFactoryDefinitionTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\DependencyInjection;
+namespace Flexi\Test\Infrastructure\DependencyInjection;
 
-use CubaDevOps\Flexi\Infrastructure\DependencyInjection\ServiceFactoryDefinition;
+use Flexi\Infrastructure\DependencyInjection\ServiceFactoryDefinition;
 use PHPUnit\Framework\TestCase;
 
 class ServiceFactoryDefinitionTest extends TestCase

--- a/tests/Infrastructure/DependencyInjection/ServiceTest.php
+++ b/tests/Infrastructure/DependencyInjection/ServiceTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\DependencyInjection;
+namespace Flexi\Test\Infrastructure\DependencyInjection;
 
 use Flexi\Contracts\Interfaces\ServiceDefinitionInterface;
-use CubaDevOps\Flexi\Infrastructure\DependencyInjection\Service;
-use CubaDevOps\Flexi\Domain\ValueObjects\ServiceType;
+use Flexi\Infrastructure\DependencyInjection\Service;
+use Flexi\Domain\ValueObjects\ServiceType;
 use PHPUnit\Framework\TestCase;
 
 class ServiceTest extends TestCase

--- a/tests/Infrastructure/DependencyInjection/ServicesDefinitionParserTest.php
+++ b/tests/Infrastructure/DependencyInjection/ServicesDefinitionParserTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\DependencyInjection;
+namespace Flexi\Test\Infrastructure\DependencyInjection;
 
-use CubaDevOps\Flexi\Infrastructure\DependencyInjection\ServicesDefinitionParser;
-use CubaDevOps\Flexi\Test\TestData\TestDoubles\ServicesArrayCache;
+use Flexi\Infrastructure\DependencyInjection\ServicesDefinitionParser;
+use Flexi\Test\TestData\TestDoubles\ServicesArrayCache;
 use PHPUnit\Framework\TestCase;
 
 final class ServicesDefinitionParserTest extends TestCase

--- a/tests/Infrastructure/Factories/BusFactoryTest.php
+++ b/tests/Infrastructure/Factories/BusFactoryTest.php
@@ -2,18 +2,18 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\Factories;
+namespace Flexi\Test\Infrastructure\Factories;
 
 use Flexi\Contracts\Interfaces\ConfigurationRepositoryInterface;
 use Flexi\Contracts\Interfaces\ObjectBuilderInterface;
-use CubaDevOps\Flexi\Infrastructure\Bus\CommandBus;
-use CubaDevOps\Flexi\Infrastructure\Bus\EventBus;
-use CubaDevOps\Flexi\Infrastructure\Bus\QueryBus;
-use CubaDevOps\Flexi\Infrastructure\Factories\BusFactory;
-use CubaDevOps\Flexi\Infrastructure\Classes\InMemoryCache;
-use CubaDevOps\Flexi\Infrastructure\DependencyInjection\HandlersDefinitionParser;
-use CubaDevOps\Flexi\Infrastructure\DependencyInjection\ListenersDefinitionParser;
-use CubaDevOps\Flexi\Domain\Interfaces\ConfigurationFilesProviderInterface;
+use Flexi\Infrastructure\Bus\CommandBus;
+use Flexi\Infrastructure\Bus\EventBus;
+use Flexi\Infrastructure\Bus\QueryBus;
+use Flexi\Infrastructure\Factories\BusFactory;
+use Flexi\Infrastructure\Classes\InMemoryCache;
+use Flexi\Infrastructure\DependencyInjection\HandlersDefinitionParser;
+use Flexi\Infrastructure\DependencyInjection\ListenersDefinitionParser;
+use Flexi\Domain\Interfaces\ConfigurationFilesProviderInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;

--- a/tests/Infrastructure/Factories/ContainerFactoryTest.php
+++ b/tests/Infrastructure/Factories/ContainerFactoryTest.php
@@ -2,22 +2,22 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\Factories;
+namespace Flexi\Test\Infrastructure\Factories;
 
-use CubaDevOps\Flexi\Infrastructure\Factories\ContainerFactory;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleDetectorInterface;
-use CubaDevOps\Flexi\Infrastructure\Factories\CacheFactoryInterface;
-use CubaDevOps\Flexi\Infrastructure\Factories\HybridModuleDetector;
-use CubaDevOps\Flexi\Infrastructure\Factories\LocalModuleDetector;
-use CubaDevOps\Flexi\Infrastructure\Factories\VendorModuleDetector;
-use CubaDevOps\Flexi\Infrastructure\Factories\DefaultCacheFactory;
-use CubaDevOps\Flexi\Infrastructure\DependencyInjection\Container;
-use CubaDevOps\Flexi\Infrastructure\DependencyInjection\ServicesDefinitionParser;
-use CubaDevOps\Flexi\Infrastructure\Classes\InMemoryCache;
-use CubaDevOps\Flexi\Infrastructure\Classes\ObjectBuilder;
-use CubaDevOps\Flexi\Infrastructure\Classes\Configuration;
-use CubaDevOps\Flexi\Infrastructure\Classes\ConfigurationRepository;
-use CubaDevOps\Flexi\Domain\Interfaces\ConfigurationFilesProviderInterface;
+use Flexi\Infrastructure\Factories\ContainerFactory;
+use Flexi\Domain\Interfaces\ModuleDetectorInterface;
+use Flexi\Infrastructure\Factories\CacheFactoryInterface;
+use Flexi\Infrastructure\Factories\HybridModuleDetector;
+use Flexi\Infrastructure\Factories\LocalModuleDetector;
+use Flexi\Infrastructure\Factories\VendorModuleDetector;
+use Flexi\Infrastructure\Factories\DefaultCacheFactory;
+use Flexi\Infrastructure\DependencyInjection\Container;
+use Flexi\Infrastructure\DependencyInjection\ServicesDefinitionParser;
+use Flexi\Infrastructure\Classes\InMemoryCache;
+use Flexi\Infrastructure\Classes\ObjectBuilder;
+use Flexi\Infrastructure\Classes\Configuration;
+use Flexi\Infrastructure\Classes\ConfigurationRepository;
+use Flexi\Domain\Interfaces\ConfigurationFilesProviderInterface;
 use Flexi\Contracts\Interfaces\CacheInterface;
 use Flexi\Contracts\Interfaces\ObjectBuilderInterface;
 use PHPUnit\Framework\TestCase;
@@ -88,7 +88,7 @@ class ContainerFactoryTest extends TestCase
 
         // Mock the services parser to return test services when called
         $testServices = [
-            'test-service' => $this->createMock(\CubaDevOps\Flexi\Infrastructure\DependencyInjection\Service::class)
+            'test-service' => $this->createMock(\Flexi\Infrastructure\DependencyInjection\Service::class)
         ];
 
         $this->servicesDefinitionParser
@@ -201,7 +201,7 @@ class ContainerFactoryTest extends TestCase
     public function testGetInstanceWithFileAndMockedDependencies(): void
     {
         // Mock the services parser to return test services
-        $mockService = $this->createMock(\CubaDevOps\Flexi\Infrastructure\DependencyInjection\Service::class);
+        $mockService = $this->createMock(\Flexi\Infrastructure\DependencyInjection\Service::class);
         $testServices = [
             'test-service-mocked' => $mockService
         ];

--- a/tests/Infrastructure/Factories/HybridModuleDetectorTest.php
+++ b/tests/Infrastructure/Factories/HybridModuleDetectorTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\Factories;
+namespace Flexi\Test\Infrastructure\Factories;
 
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleType;
-use CubaDevOps\Flexi\Infrastructure\Factories\HybridModuleDetector;
-use CubaDevOps\Flexi\Infrastructure\Factories\LocalModuleDetector;
-use CubaDevOps\Flexi\Infrastructure\Factories\VendorModuleDetector;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleCacheManagerInterface;
+use Flexi\Domain\ValueObjects\ModuleType;
+use Flexi\Infrastructure\Factories\HybridModuleDetector;
+use Flexi\Infrastructure\Factories\LocalModuleDetector;
+use Flexi\Infrastructure\Factories\VendorModuleDetector;
+use Flexi\Domain\Interfaces\ModuleCacheManagerInterface;
 use PHPUnit\Framework\TestCase;
 
 final class HybridModuleDetectorTest extends TestCase
@@ -184,7 +184,7 @@ final class HybridModuleDetectorTest extends TestCase
 final class NullCacheManager implements ModuleCacheManagerInterface
 {
     public bool $valid = false;
-    /** @var array<int, \CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo> */
+    /** @var array<int, \Flexi\Domain\ValueObjects\ModuleInfo> */
     public array $modules = [];
 
     public function getCachedModules(): array

--- a/tests/Infrastructure/Factories/LocalModuleDetectorTest.php
+++ b/tests/Infrastructure/Factories/LocalModuleDetectorTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\Factories;
+namespace Flexi\Test\Infrastructure\Factories;
 
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo;
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleType;
-use CubaDevOps\Flexi\Infrastructure\Factories\LocalModuleDetector;
+use Flexi\Domain\ValueObjects\ModuleInfo;
+use Flexi\Domain\ValueObjects\ModuleType;
+use Flexi\Infrastructure\Factories\LocalModuleDetector;
 use PHPUnit\Framework\TestCase;
 
 final class LocalModuleDetectorTest extends TestCase

--- a/tests/Infrastructure/Factories/RefactoredFactoriesTest.php
+++ b/tests/Infrastructure/Factories/RefactoredFactoriesTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Tests\Infrastructure\Factories;
+namespace Flexi\Tests\Infrastructure\Factories;
 
-use CubaDevOps\Flexi\Infrastructure\Factories\BusFactory;
-use CubaDevOps\Flexi\Infrastructure\Factories\RouterFactory;
-use CubaDevOps\Flexi\Infrastructure\Bus\CommandBus;
-use CubaDevOps\Flexi\Infrastructure\Bus\QueryBus;
-use CubaDevOps\Flexi\Infrastructure\Bus\EventBus;
+use Flexi\Infrastructure\Factories\BusFactory;
+use Flexi\Infrastructure\Factories\RouterFactory;
+use Flexi\Infrastructure\Bus\CommandBus;
+use Flexi\Infrastructure\Bus\QueryBus;
+use Flexi\Infrastructure\Bus\EventBus;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 

--- a/tests/Infrastructure/Factories/RouterFactoryTest.php
+++ b/tests/Infrastructure/Factories/RouterFactoryTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\Factories;
+namespace Flexi\Test\Infrastructure\Factories;
 
-use CubaDevOps\Flexi\Domain\ValueObjects\ConfigurationType;
-use CubaDevOps\Flexi\Infrastructure\DependencyInjection\RoutesDefinitionParser;
-use CubaDevOps\Flexi\Infrastructure\Factories\RouterFactory;
-use CubaDevOps\Flexi\Infrastructure\Http\Route;
-use CubaDevOps\Flexi\Infrastructure\Http\Router;
-use CubaDevOps\Flexi\Domain\Interfaces\ConfigurationFilesProviderInterface;
+use Flexi\Domain\ValueObjects\ConfigurationType;
+use Flexi\Infrastructure\DependencyInjection\RoutesDefinitionParser;
+use Flexi\Infrastructure\Factories\RouterFactory;
+use Flexi\Infrastructure\Http\Route;
+use Flexi\Infrastructure\Http\Router;
+use Flexi\Domain\Interfaces\ConfigurationFilesProviderInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use Flexi\Contracts\Interfaces\EventBusInterface;
 use Flexi\Contracts\Interfaces\ObjectBuilderInterface;

--- a/tests/Infrastructure/Factories/VendorModuleDetectorTest.php
+++ b/tests/Infrastructure/Factories/VendorModuleDetectorTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\Factories;
+namespace Flexi\Test\Infrastructure\Factories;
 
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleInfo;
-use CubaDevOps\Flexi\Domain\ValueObjects\ModuleType;
-use CubaDevOps\Flexi\Infrastructure\Factories\VendorModuleDetector;
-use CubaDevOps\Flexi\Domain\Interfaces\ModuleCacheManagerInterface;
+use Flexi\Domain\ValueObjects\ModuleInfo;
+use Flexi\Domain\ValueObjects\ModuleType;
+use Flexi\Infrastructure\Factories\VendorModuleDetector;
+use Flexi\Domain\Interfaces\ModuleCacheManagerInterface;
 use PHPUnit\Framework\TestCase;
 
 final class VendorModuleDetectorTest extends TestCase

--- a/tests/Infrastructure/Http/RouteTest.php
+++ b/tests/Infrastructure/Http/RouteTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\Http;
+namespace Flexi\Test\Infrastructure\Http;
 
-use CubaDevOps\Flexi\Infrastructure\Http\Route;
+use Flexi\Infrastructure\Http\Route;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Server\MiddlewareInterface;
 

--- a/tests/Infrastructure/Http/RouterTest.php
+++ b/tests/Infrastructure/Http/RouterTest.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\Http;
+namespace Flexi\Test\Infrastructure\Http;
 
 use Flexi\Contracts\Interfaces\EventBusInterface;
 use Flexi\Contracts\Interfaces\ObjectBuilderInterface;
 use Flexi\Contracts\Interfaces\CacheInterface;
-use CubaDevOps\Flexi\Infrastructure\Classes\Collection;
-use CubaDevOps\Flexi\Infrastructure\Http\Route;
-use CubaDevOps\Flexi\Infrastructure\Http\Router;
-use CubaDevOps\Flexi\Test\TestData\TestDoubles\RouterMock;
-use CubaDevOps\Flexi\Test\TestData\TestDoubles\TestHttpHandler;
+use Flexi\Infrastructure\Classes\Collection;
+use Flexi\Infrastructure\Http\Route;
+use Flexi\Infrastructure\Http\Router;
+use Flexi\Test\TestData\TestDoubles\RouterMock;
+use Flexi\Test\TestData\TestDoubles\TestHttpHandler;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerExceptionInterface;
@@ -931,7 +931,7 @@ class RouterTest extends TestCase
             ->method('dispatch')
             ->willReturnCallback(function($event) use ($customResponseMock) {
                 // Simulate event listener setting a custom response
-                /** @var \CubaDevOps\Flexi\Domain\Events\RouteNotFoundEvent $event */
+                /** @var \Flexi\Domain\Events\RouteNotFoundEvent $event */
                 $event->setResponse($customResponseMock);
                 return $event;
             });

--- a/tests/Infrastructure/Services/CommandExecutorTest.php
+++ b/tests/Infrastructure/Services/CommandExecutorTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\Services;
+namespace Flexi\Test\Infrastructure\Services;
 
-use CubaDevOps\Flexi\Infrastructure\Services\CommandExecutor;
-use CubaDevOps\Flexi\Application\Services\CommandExecutorInterface;
+use Flexi\Infrastructure\Services\CommandExecutor;
+use Flexi\Application\Services\CommandExecutorInterface;
 use PHPUnit\Framework\TestCase;
 
 class CommandExecutorTest extends TestCase

--- a/tests/Infrastructure/TestEnvironmentTest.php
+++ b/tests/Infrastructure/TestEnvironmentTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure;
+namespace Flexi\Test\Infrastructure;
 
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Infrastructure/Ui/Cli/CliInputParserTest.php
+++ b/tests/Infrastructure/Ui/Cli/CliInputParserTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\Ui\Cli;
+namespace Flexi\Test\Infrastructure\Ui\Cli;
 
-use CubaDevOps\Flexi\Infrastructure\Ui\Cli\CliInput;
-use CubaDevOps\Flexi\Infrastructure\Ui\Cli\CliInputParser;
-use CubaDevOps\Flexi\Infrastructure\Ui\Cli\CliType;
+use Flexi\Infrastructure\Ui\Cli\CliInput;
+use Flexi\Infrastructure\Ui\Cli\CliInputParser;
+use Flexi\Infrastructure\Ui\Cli\CliType;
 use PHPUnit\Framework\TestCase;
 
 class CliInputParserTest extends TestCase

--- a/tests/Infrastructure/Ui/Cli/CliInputTest.php
+++ b/tests/Infrastructure/Ui/Cli/CliInputTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\Ui\Cli;
+namespace Flexi\Test\Infrastructure\Ui\Cli;
 
-use CubaDevOps\Flexi\Infrastructure\Ui\Cli\CliInput;
+use Flexi\Infrastructure\Ui\Cli\CliInput;
 use PHPUnit\Framework\TestCase;
 
 class CliInputTest extends TestCase

--- a/tests/Infrastructure/Ui/Cli/CommandHandlerTest.php
+++ b/tests/Infrastructure/Ui/Cli/CommandHandlerTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\Ui\Cli;
+namespace Flexi\Test\Infrastructure\Ui\Cli;
 
-use CubaDevOps\Flexi\Domain\Commands\NotFoundCommand;
-use CubaDevOps\Flexi\Infrastructure\Ui\Cli\DTOFactory;
-use CubaDevOps\Flexi\Infrastructure\Ui\Cli\CommandHandler;
-use CubaDevOps\Flexi\Infrastructure\Ui\Cli\CliInput;
-use CubaDevOps\Flexi\Infrastructure\Bus\CommandBus;
+use Flexi\Domain\Commands\NotFoundCommand;
+use Flexi\Infrastructure\Ui\Cli\DTOFactory;
+use Flexi\Infrastructure\Ui\Cli\CommandHandler;
+use Flexi\Infrastructure\Ui\Cli\CliInput;
+use Flexi\Infrastructure\Bus\CommandBus;
 use Flexi\Contracts\Interfaces\BusInterface;
 use Flexi\Contracts\Interfaces\CliDTOInterface;
 use Flexi\Contracts\Interfaces\MessageInterface;
@@ -109,7 +109,7 @@ class CommandHandlerTest extends TestCase
         /** @var CommandBus|MockObject $commandBus */
         $commandBus = $this->createMock(CommandBus::class);
         $commandBus->method('hasHandler')->willReturn(true);
-        $commandBus->method('getDtoClassFromAlias')->willReturn('CubaDevOps\Flexi\Test\TestData\Commands\TestCommand');
+        $commandBus->method('getDtoClassFromAlias')->willReturn('Flexi\Test\TestData\Commands\TestCommand');
         $commandBus->method('execute')->willReturn($message);
 
         $input = new CliInput('test-command', ['param' => 'value']);
@@ -187,7 +187,7 @@ class CommandHandlerTest extends TestCase
         /** @var CommandBus|MockObject $commandBus */
         $commandBus = $this->createMock(CommandBus::class);
         $commandBus->method('hasHandler')->willReturn(true);
-        $commandBus->method('getDtoClassFromAlias')->willReturn('CubaDevOps\\Flexi\\Test\\TestData\\Commands\\TestCommand');
+        $commandBus->method('getDtoClassFromAlias')->willReturn('Flexi\\Test\\TestData\\Commands\\TestCommand');
         $commandBus->method('execute')->willReturn($message);
 
         $complexArgs = [
@@ -258,7 +258,7 @@ class CommandHandlerTest extends TestCase
         /** @var CommandBus&MockObject $commandBus1 */
         $commandBus1 = $this->createMock(CommandBus::class);
         $commandBus1->method('hasHandler')->willReturn(true);
-        $commandBus1->method('getDtoClassFromAlias')->willReturn('CubaDevOps\Flexi\Test\TestData\Commands\TestCommand');
+        $commandBus1->method('getDtoClassFromAlias')->willReturn('Flexi\Test\TestData\Commands\TestCommand');
         $commandBus1->method('execute')->willReturn($message1);
 
         $input1 = new CliInput('numeric-command', ['count' => 42, 'timeout' => 30]);
@@ -275,7 +275,7 @@ class CommandHandlerTest extends TestCase
         /** @var CommandBus&MockObject $commandBus2 */
         $commandBus2 = $this->createMock(CommandBus::class);
         $commandBus2->method('hasHandler')->willReturn(true);
-        $commandBus2->method('getDtoClassFromAlias')->willReturn('CubaDevOps\Flexi\Test\TestData\Commands\TestCommand');
+        $commandBus2->method('getDtoClassFromAlias')->willReturn('Flexi\Test\TestData\Commands\TestCommand');
         $commandBus2->method('execute')->willReturn($message2);
 
         $input2 = new CliInput('flag-command', ['verbose' => true, 'debug' => false]);
@@ -298,7 +298,7 @@ class CommandHandlerTest extends TestCase
         /** @var CommandBus&MockObject $commandBus */
         $commandBus = $this->createMock(CommandBus::class);
         $commandBus->method('hasHandler')->willReturn(true);
-        $commandBus->method('getDtoClassFromAlias')->willReturn('CubaDevOps\Flexi\Test\TestData\Commands\TestCommand');
+        $commandBus->method('getDtoClassFromAlias')->willReturn('Flexi\Test\TestData\Commands\TestCommand');
         $commandBus->method('execute')->willReturn($emptyMessage);
 
         $input = new CliInput('empty-return-command', []);
@@ -393,7 +393,7 @@ class CommandHandlerTest extends TestCase
         /** @var CommandBus&MockObject $commandBus */
         $commandBus = $this->createMock(CommandBus::class);
         $commandBus->method('hasHandler')->willReturn(true);
-        $commandBus->method('getDtoClassFromAlias')->willReturn('CubaDevOps\Flexi\Test\TestData\Commands\TestCommand');
+        $commandBus->method('getDtoClassFromAlias')->willReturn('Flexi\Test\TestData\Commands\TestCommand');
         $commandBus->method('execute')->willReturn($message);
 
         // Create CommandHandler instance - this should cover constructor
@@ -419,7 +419,7 @@ class CommandHandlerTest extends TestCase
 
         // Mock that handler exists for 'module-info' command
         $commandBus->method('hasHandler')->with('module-info')->willReturn(true);
-        $commandBus->method('getDtoClassFromAlias')->with('module-info')->willReturn('CubaDevOps\\Flexi\\Application\\Commands\\ModuleInfoCommand');
+        $commandBus->method('getDtoClassFromAlias')->with('module-info')->willReturn('Flexi\\Application\\Commands\\ModuleInfoCommand');
 
         // Create input with help flag enabled
         $input = new CliInput('module-info', ['module' => 'test-module'], 'command', true);

--- a/tests/Infrastructure/Ui/Cli/ConsoleApplicationTest.php
+++ b/tests/Infrastructure/Ui/Cli/ConsoleApplicationTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\Ui\Cli;
+namespace Flexi\Test\Infrastructure\Ui\Cli;
 
-use CubaDevOps\Flexi\Infrastructure\Ui\Cli\ConsoleApplication;
-use CubaDevOps\Flexi\Infrastructure\Ui\Cli\CliType;
+use Flexi\Infrastructure\Ui\Cli\ConsoleApplication;
+use Flexi\Infrastructure\Ui\Cli\CliType;
 use PHPUnit\Framework\TestCase;
 
 class ConsoleApplicationTest extends TestCase

--- a/tests/Infrastructure/Ui/Cli/ConsoleExceptionFormatterTest.php
+++ b/tests/Infrastructure/Ui/Cli/ConsoleExceptionFormatterTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\Ui\Cli;
+namespace Flexi\Test\Infrastructure\Ui\Cli;
 
-use CubaDevOps\Flexi\Infrastructure\Ui\Cli\ConsoleExceptionFormatter;
+use Flexi\Infrastructure\Ui\Cli\ConsoleExceptionFormatter;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 

--- a/tests/Infrastructure/Ui/Cli/ConsoleOutputFormatterTest.php
+++ b/tests/Infrastructure/Ui/Cli/ConsoleOutputFormatterTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\Ui\Cli;
+namespace Flexi\Test\Infrastructure\Ui\Cli;
 
-use CubaDevOps\Flexi\Infrastructure\Ui\Cli\ConsoleOutputFormatter;
+use Flexi\Infrastructure\Ui\Cli\ConsoleOutputFormatter;
 use PHPUnit\Framework\TestCase;
 
 final class ConsoleOutputFormatterTest extends TestCase

--- a/tests/Infrastructure/Ui/Cli/DTOFactoryTest.php
+++ b/tests/Infrastructure/Ui/Cli/DTOFactoryTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\Ui\Cli;
+namespace Flexi\Test\Infrastructure\Ui\Cli;
 
 use Flexi\Contracts\Interfaces\BusInterface;
-use CubaDevOps\Flexi\Test\TestData\TestDoubles\DummyDTO;
-use CubaDevOps\Flexi\Domain\Commands\NotFoundCommand;
-use CubaDevOps\Flexi\Infrastructure\Ui\Cli\DTOFactory;
+use Flexi\Test\TestData\TestDoubles\DummyDTO;
+use Flexi\Domain\Commands\NotFoundCommand;
+use Flexi\Infrastructure\Ui\Cli\DTOFactory;
 use PHPUnit\Framework\TestCase;
 
 class DTOFactoryTest extends TestCase

--- a/tests/Infrastructure/Ui/Cli/EventHandlerTest.php
+++ b/tests/Infrastructure/Ui/Cli/EventHandlerTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\Ui\Cli;
+namespace Flexi\Test\Infrastructure\Ui\Cli;
 
-use CubaDevOps\Flexi\Domain\Events\Event;
-use CubaDevOps\Flexi\Infrastructure\Ui\Cli\CliInput;
-use CubaDevOps\Flexi\Infrastructure\Ui\Cli\EventHandler;
+use Flexi\Domain\Events\Event;
+use Flexi\Infrastructure\Ui\Cli\CliInput;
+use Flexi\Infrastructure\Ui\Cli\EventHandler;
 use Flexi\Contracts\Interfaces\EventBusInterface;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Infrastructure/Ui/Cli/QueryHandlerTest.php
+++ b/tests/Infrastructure/Ui/Cli/QueryHandlerTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\Ui\Cli;
+namespace Flexi\Test\Infrastructure\Ui\Cli;
 
-use CubaDevOps\Flexi\Application\Commands\ModuleInfoCommand;
-use CubaDevOps\Flexi\Infrastructure\Bus\QueryBus;
-use CubaDevOps\Flexi\Infrastructure\Ui\Cli\CliInput;
-use CubaDevOps\Flexi\Infrastructure\Ui\Cli\QueryHandler;
+use Flexi\Application\Commands\ModuleInfoCommand;
+use Flexi\Infrastructure\Bus\QueryBus;
+use Flexi\Infrastructure\Ui\Cli\CliInput;
+use Flexi\Infrastructure\Ui\Cli\QueryHandler;
 use Flexi\Contracts\Interfaces\CliDTOInterface;
 use Flexi\Contracts\Interfaces\MessageInterface;
 use PHPUnit\Framework\TestCase;
@@ -105,7 +105,7 @@ class QueryHandlerTest extends TestCase
     {
         $queryBusMock = $this->createMock(QueryBus::class);
         $queryBusMock->method('hasHandler')->willReturn(true);
-        $queryBusMock->method('getDtoClassFromAlias')->willReturn('CubaDevOps\\Flexi\\Test\\TestData\\Queries\\TestQuery');
+        $queryBusMock->method('getDtoClassFromAlias')->willReturn('Flexi\\Test\\TestData\\Queries\\TestQuery');
 
         $messageMock = $this->createMock(MessageInterface::class);
         $messageMock->method('__toString')->willReturn('Complex query response');
@@ -151,7 +151,7 @@ class QueryHandlerTest extends TestCase
 
         // Mock that ModuleInfoCommand has a handler and will be returned
         $queryBusMock->method('hasHandler')->willReturn(true);
-        $queryBusMock->method('getDtoClassFromAlias')->willReturn(\CubaDevOps\Flexi\Application\Commands\ModuleInfoCommand::class);
+        $queryBusMock->method('getDtoClassFromAlias')->willReturn(\Flexi\Application\Commands\ModuleInfoCommand::class);
 
         $handler = new QueryHandler($queryBusMock);
         $input = new CliInput('module:info', ['module' => 'test'], 'query', true); // help flag = true

--- a/tests/Infrastructure/Ui/Web/ApplicationTest.php
+++ b/tests/Infrastructure/Ui/Web/ApplicationTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\Infrastructure\Ui\Web;
+namespace Flexi\Test\Infrastructure\Ui\Web;
 
-use CubaDevOps\Flexi\Infrastructure\Ui\Web\Application;
+use Flexi\Infrastructure\Ui\Web\Application;
 use Flexi\Contracts\Interfaces\ConfigurationInterface;
-use CubaDevOps\Flexi\Infrastructure\Factories\RouterFactory;
-use CubaDevOps\Flexi\Infrastructure\Http\Router;
+use Flexi\Infrastructure\Factories\RouterFactory;
+use Flexi\Infrastructure\Http\Router;
 use GuzzleHttp\Psr7\Stream;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;

--- a/tests/README.md
+++ b/tests/README.md
@@ -86,7 +86,7 @@ Tests automatically benefit from the testing environment. No special configurati
 ```php
 <?php
 
-namespace CubaDevOps\Flexi\Test\YourNamespace;
+namespace Flexi\Test\YourNamespace;
 
 use PHPUnit\Framework\TestCase;
 

--- a/tests/TestData/Commands/TestCommand.php
+++ b/tests/TestData/Commands/TestCommand.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\TestData\Commands;
+namespace Flexi\Test\TestData\Commands;
 
 use Flexi\Contracts\Interfaces\DTOInterface;
 

--- a/tests/TestData/Configurations/commands-bus-glob-test.json
+++ b/tests/TestData/Configurations/commands-bus-glob-test.json
@@ -1,8 +1,8 @@
 {
   "handlers": [
     {
-      "id": "CubaDevOps\\Flexi\\Test\\TestData\\Commands\\TestCommand",
-      "handler": "CubaDevOps\\Flexi\\Test\\TestData\\Handlers\\TestCommandHandler"
+      "id": "Flexi\\Test\\TestData\\Commands\\TestCommand",
+      "handler": "Flexi\\Test\\TestData\\Handlers\\TestCommandHandler"
     },
     {
       "glob": "tests/TestData/Configurations/extra-commands/commands.json"

--- a/tests/TestData/Configurations/commands-bus-test.json
+++ b/tests/TestData/Configurations/commands-bus-test.json
@@ -1,9 +1,9 @@
 {
   "handlers": [
     {
-      "id": "CubaDevOps\\Flexi\\Test\\TestData\\Commands\\TestCommand",
+      "id": "Flexi\\Test\\TestData\\Commands\\TestCommand",
       "cli_alias": "test",
-      "handler": "CubaDevOps\\Flexi\\Test\\TestData\\Handlers\\TestCommandHandler"
+      "handler": "Flexi\\Test\\TestData\\Handlers\\TestCommandHandler"
     }
   ]
 }

--- a/tests/TestData/Configurations/container-test.json
+++ b/tests/TestData/Configurations/container-test.json
@@ -3,38 +3,38 @@
     {
       "name": "Flexi\\Contracts\\ConfigurationRepositoryInterface",
       "class": {
-        "name": "CubaDevOps\\Flexi\\Infrastructure\\Classes\\ConfigurationRepository",
+        "name": "Flexi\\Infrastructure\\Classes\\ConfigurationRepository",
         "arguments": []
       }
     },
     {
-      "name": "CubaDevOps\\Flexi\\Infrastructure\\Classes\\Configuration",
+      "name": "Flexi\\Infrastructure\\Classes\\Configuration",
       "class": {
-        "name": "CubaDevOps\\Flexi\\Infrastructure\\Classes\\Configuration",
+        "name": "Flexi\\Infrastructure\\Classes\\Configuration",
         "arguments": [
           "@Flexi\\Contracts\\ConfigurationRepositoryInterface"
         ]
       }
     },
     {
-      "name": "CubaDevOps\\Flexi\\Test\\TestData\\TestDoubles\\IsNotInstantiable",
+      "name": "Flexi\\Test\\TestData\\TestDoubles\\IsNotInstantiable",
       "factory": {
-        "class": "CubaDevOps\\Flexi\\Test\\TestData\\TestDoubles\\IsNotInstantiable",
+        "class": "Flexi\\Test\\TestData\\TestDoubles\\IsNotInstantiable",
         "method": "getInstance",
         "arguments": []
       }
     },
     {
-      "name": "CubaDevOps\\Flexi\\Test\\TestData\\TestDoubles\\HasNoConstructor",
+      "name": "Flexi\\Test\\TestData\\TestDoubles\\HasNoConstructor",
       "class": {
-        "name": "CubaDevOps\\Flexi\\Test\\TestData\\TestDoubles\\HasNoConstructor",
+        "name": "Flexi\\Test\\TestData\\TestDoubles\\HasNoConstructor",
         "arguments": []
       }
     },
     {
-      "name": "CubaDevOps\\Flexi\\Domain\\Classes\\Router",
+      "name": "Flexi\\Domain\\Classes\\Router",
       "factory": {
-        "class": "CubaDevOps\\Flexi\\Infrastructure\\Factories\\RouterFactory",
+        "class": "Flexi\\Infrastructure\\Factories\\RouterFactory",
         "method": "getInstance",
         "arguments": [
           "@Flexi\\Contracts\\SessionStorageInterface",

--- a/tests/TestData/Configurations/extra-commands/commands.json
+++ b/tests/TestData/Configurations/extra-commands/commands.json
@@ -1,9 +1,9 @@
 {
   "handlers": [
     {
-      "id": "CubaDevOps\\Flexi\\Test\\TestData\\Commands\\ExtraTestCommand",
+      "id": "Flexi\\Test\\TestData\\Commands\\ExtraTestCommand",
       "cli_alias": "extra-test",
-      "handler": "CubaDevOps\\Flexi\\Test\\TestData\\Handlers\\ExtraTestCommandHandler"
+      "handler": "Flexi\\Test\\TestData\\Handlers\\ExtraTestCommandHandler"
     }
   ]
 }

--- a/tests/TestData/Configurations/modules/test-module/commands.json
+++ b/tests/TestData/Configurations/modules/test-module/commands.json
@@ -1,9 +1,9 @@
 {
   "handlers": [
     {
-      "id": "CubaDevOps\\Flexi\\Test\\TestData\\Commands\\AnotherTestCommand",
+      "id": "Flexi\\Test\\TestData\\Commands\\AnotherTestCommand",
       "cli_alias": "another-test",
-      "handler": "CubaDevOps\\Flexi\\Test\\TestData\\Handlers\\AnotherTestCommandHandler"
+      "handler": "Flexi\\Test\\TestData\\Handlers\\AnotherTestCommandHandler"
     }
   ]
 }

--- a/tests/TestData/Configurations/queries-bus-core-test.json
+++ b/tests/TestData/Configurations/queries-bus-core-test.json
@@ -1,9 +1,9 @@
 {
   "handlers": [
     {
-      "id": "CubaDevOps\\Flexi\\Test\\TestData\\Queries\\TestQuery",
+      "id": "Flexi\\Test\\TestData\\Queries\\TestQuery",
       "cli_alias": "test-query",
-      "handler": "CubaDevOps\\Flexi\\Test\\TestData\\Handlers\\TestQueryHandler"
+      "handler": "Flexi\\Test\\TestData\\Handlers\\TestQueryHandler"
     }
   ]
 }

--- a/tests/TestData/Configurations/queries-bus-glob-test.json
+++ b/tests/TestData/Configurations/queries-bus-glob-test.json
@@ -1,9 +1,9 @@
 {
   "handlers": [
     {
-      "id": "CubaDevOps\\Flexi\\Test\\TestData\\Queries\\TestQuery",
+      "id": "Flexi\\Test\\TestData\\Queries\\TestQuery",
       "cli_alias": "test-query",
-      "handler": "CubaDevOps\\Flexi\\Test\\TestData\\Handlers\\TestQueryHandler"
+      "handler": "Flexi\\Test\\TestData\\Handlers\\TestQueryHandler"
     },
     {
       "glob": "tests/TestData/Configurations/queries-extra/queries.json"

--- a/tests/TestData/Configurations/queries-bus-test.json
+++ b/tests/TestData/Configurations/queries-bus-test.json
@@ -1,14 +1,14 @@
 {
   "handlers": [
     {
-      "id": "CubaDevOps\\Flexi\\Modules\\HealthCheck\\Application\\Queries\\GetVersionQuery",
+      "id": "Flexi\\Modules\\HealthCheck\\Application\\Queries\\GetVersionQuery",
       "cli_alias": "version",
-      "handler": "CubaDevOps\\Flexi\\Modules\\HealthCheck\\Application\\UseCase\\Health"
+      "handler": "Flexi\\Modules\\HealthCheck\\Application\\UseCase\\Health"
     },
     {
-      "id": "CubaDevOps\\Flexi\\Modules\\DevTools\\Application\\Queries\\ListQueriesQuery",
+      "id": "Flexi\\Modules\\DevTools\\Application\\Queries\\ListQueriesQuery",
       "cli_alias": "query:list",
-      "handler": "CubaDevOps\\Flexi\\Modules\\DevTools\\Application\\UseCase\\ListQueries"
+      "handler": "Flexi\\Modules\\DevTools\\Application\\UseCase\\ListQueries"
     }
   ]
 }

--- a/tests/TestData/Configurations/queries-extra/queries.json
+++ b/tests/TestData/Configurations/queries-extra/queries.json
@@ -1,9 +1,9 @@
 {
   "handlers": [
     {
-      "id": "CubaDevOps\\Flexi\\Test\\TestData\\Queries\\ExtraTestQuery",
+      "id": "Flexi\\Test\\TestData\\Queries\\ExtraTestQuery",
       "cli_alias": "extra-test-query",
-      "handler": "CubaDevOps\\Flexi\\Test\\TestData\\Handlers\\ExtraTestQueryHandler"
+      "handler": "Flexi\\Test\\TestData\\Handlers\\ExtraTestQueryHandler"
     }
   ]
 }

--- a/tests/TestData/Handlers/TestCommandHandler.php
+++ b/tests/TestData/Handlers/TestCommandHandler.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\TestData\Handlers;
+namespace Flexi\Test\TestData\Handlers;
 
 use Flexi\Contracts\Classes\PlainTextMessage;
 use Flexi\Contracts\Interfaces\DTOInterface;

--- a/tests/TestData/Handlers/TestQueryHandler.php
+++ b/tests/TestData/Handlers/TestQueryHandler.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\TestData\Handlers;
+namespace Flexi\Test\TestData\Handlers;
 
 use Flexi\Contracts\Classes\PlainTextMessage;
 use Flexi\Contracts\Interfaces\DTOInterface;

--- a/tests/TestData/Queries/TestQuery.php
+++ b/tests/TestData/Queries/TestQuery.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\TestData\Queries;
+namespace Flexi\Test\TestData\Queries;
 
 use Flexi\Contracts\Interfaces\DTOInterface;
 

--- a/tests/TestData/TestDoubles/Bus/GenericMessage.php
+++ b/tests/TestData/TestDoubles/Bus/GenericMessage.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\TestData\TestDoubles\Bus;
+namespace Flexi\Test\TestData\TestDoubles\Bus;
 
 final class GenericMessage
 {

--- a/tests/TestData/TestDoubles/Bus/RecordingListener.php
+++ b/tests/TestData/TestDoubles/Bus/RecordingListener.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\TestData\TestDoubles\Bus;
+namespace Flexi\Test\TestData\TestDoubles\Bus;
 
 use Flexi\Contracts\Interfaces\DTOInterface;
 use Flexi\Contracts\Interfaces\EventInterface;

--- a/tests/TestData/TestDoubles/Bus/SampleEvent.php
+++ b/tests/TestData/TestDoubles/Bus/SampleEvent.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\TestData\TestDoubles\Bus;
+namespace Flexi\Test\TestData\TestDoubles\Bus;
 
 use Flexi\Contracts\Interfaces\EventInterface;
 

--- a/tests/TestData/TestDoubles/Bus/SecondaryListener.php
+++ b/tests/TestData/TestDoubles/Bus/SecondaryListener.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\TestData\TestDoubles\Bus;
+namespace Flexi\Test\TestData\TestDoubles\Bus;
 
 final class SecondaryListener extends RecordingListener
 {

--- a/tests/TestData/TestDoubles/Configuration/ArrayConfiguration.php
+++ b/tests/TestData/TestDoubles/Configuration/ArrayConfiguration.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\TestData\TestDoubles\Configuration;
+namespace Flexi\Test\TestData\TestDoubles\Configuration;
 
 use Flexi\Contracts\Interfaces\ConfigurationInterface;
 use function sprintf;
-use CubaDevOps\Flexi\Test\TestData\TestDoubles\Configuration\ConfigurationNotFound;
+use Flexi\Test\TestData\TestDoubles\Configuration\ConfigurationNotFound;
 
 final class ArrayConfiguration implements ConfigurationInterface
 {

--- a/tests/TestData/TestDoubles/Configuration/ConfigurationNotFound.php
+++ b/tests/TestData/TestDoubles/Configuration/ConfigurationNotFound.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\TestData\TestDoubles\Configuration;
+namespace Flexi\Test\TestData\TestDoubles\Configuration;
 
 use Psr\Container\NotFoundExceptionInterface;
 

--- a/tests/TestData/TestDoubles/DummyCache.php
+++ b/tests/TestData/TestDoubles/DummyCache.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\TestData\TestDoubles;
+namespace Flexi\Test\TestData\TestDoubles;
 
 use Flexi\Contracts\Interfaces\CacheInterface;
 

--- a/tests/TestData/TestDoubles/DummyDTO.php
+++ b/tests/TestData/TestDoubles/DummyDTO.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\TestData\TestDoubles;
+namespace Flexi\Test\TestData\TestDoubles;
 
 use Flexi\Contracts\Interfaces\DTOInterface;
 

--- a/tests/TestData/TestDoubles/DummyEntity.php
+++ b/tests/TestData/TestDoubles/DummyEntity.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\TestData\TestDoubles;
+namespace Flexi\Test\TestData\TestDoubles;
 
 use Flexi\Contracts\Interfaces\EntityInterface;
 use Flexi\Contracts\ValueObjects\ID;

--- a/tests/TestData/TestDoubles/DummyResponse.php
+++ b/tests/TestData/TestDoubles/DummyResponse.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\TestData\TestDoubles;
+namespace Flexi\Test\TestData\TestDoubles;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;

--- a/tests/TestData/TestDoubles/DummyResponseFactory.php
+++ b/tests/TestData/TestDoubles/DummyResponseFactory.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\TestData\TestDoubles;
+namespace Flexi\Test\TestData\TestDoubles;
 
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;

--- a/tests/TestData/TestDoubles/DummySearchCriteria.php
+++ b/tests/TestData/TestDoubles/DummySearchCriteria.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\TestData\TestDoubles;
+namespace Flexi\Test\TestData\TestDoubles;
 
 use Flexi\Contracts\Interfaces\CriteriaInterface;
 

--- a/tests/TestData/TestDoubles/DummyStream.php
+++ b/tests/TestData/TestDoubles/DummyStream.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\TestData\TestDoubles;
+namespace Flexi\Test\TestData\TestDoubles;
 
 use Psr\Http\Message\StreamInterface;
 

--- a/tests/TestData/TestDoubles/FileHandler.php
+++ b/tests/TestData/TestDoubles/FileHandler.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\TestData\TestDoubles;
+namespace Flexi\Test\TestData\TestDoubles;
 
 use Flexi\Contracts\Classes\Traits\FileHandlerTrait;
 

--- a/tests/TestData/TestDoubles/HasNoConstructor.php
+++ b/tests/TestData/TestDoubles/HasNoConstructor.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\TestData\TestDoubles;
+namespace Flexi\Test\TestData\TestDoubles;
 
 class HasNoConstructor
 {

--- a/tests/TestData/TestDoubles/HasUnresolvableDependency.php
+++ b/tests/TestData/TestDoubles/HasUnresolvableDependency.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\TestData\TestDoubles;
+namespace Flexi\Test\TestData\TestDoubles;
 
 class HasUnresolvableDependency
 {

--- a/tests/TestData/TestDoubles/HasUnresolvableParameter.php
+++ b/tests/TestData/TestDoubles/HasUnresolvableParameter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\TestData\TestDoubles;
+namespace Flexi\Test\TestData\TestDoubles;
 
 class HasUnresolvableParameter
 {

--- a/tests/TestData/TestDoubles/IsNotInstantiable.php
+++ b/tests/TestData/TestDoubles/IsNotInstantiable.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\TestData\TestDoubles;
+namespace Flexi\Test\TestData\TestDoubles;
 
 abstract class IsNotInstantiable
 {

--- a/tests/TestData/TestDoubles/Modules/ModuleEnvironmentManagerAlwaysHas.php
+++ b/tests/TestData/TestDoubles/Modules/ModuleEnvironmentManagerAlwaysHas.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\TestData\TestDoubles\Modules;
+namespace Flexi\Test\TestData\TestDoubles\Modules;
 
-use CubaDevOps\Flexi\Infrastructure\Classes\ModuleEnvironmentManager;
+use Flexi\Infrastructure\Classes\ModuleEnvironmentManager;
 
 final class ModuleEnvironmentManagerAlwaysHas extends ModuleEnvironmentManager
 {

--- a/tests/TestData/TestDoubles/Modules/ModuleEnvironmentManagerRemovalFails.php
+++ b/tests/TestData/TestDoubles/Modules/ModuleEnvironmentManagerRemovalFails.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\TestData\TestDoubles\Modules;
+namespace Flexi\Test\TestData\TestDoubles\Modules;
 
-use CubaDevOps\Flexi\Infrastructure\Classes\ModuleEnvironmentManager;
+use Flexi\Infrastructure\Classes\ModuleEnvironmentManager;
 
 final class ModuleEnvironmentManagerRemovalFails extends ModuleEnvironmentManager
 {

--- a/tests/TestData/TestDoubles/NotFoundCliCommand.php
+++ b/tests/TestData/TestDoubles/NotFoundCliCommand.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\TestData\TestDoubles;
+namespace Flexi\Test\TestData\TestDoubles;
 
 class NotFoundCliCommand extends DummyDTO
 {

--- a/tests/TestData/TestDoubles/RouteMock.php
+++ b/tests/TestData/TestDoubles/RouteMock.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\TestData\TestDoubles;
+namespace Flexi\Test\TestData\TestDoubles;
 
-use CubaDevOps\Flexi\Infrastructure\Http\Route;
+use Flexi\Infrastructure\Http\Route;
 
 class RouteMock extends Route
 {

--- a/tests/TestData/TestDoubles/RouterMock.php
+++ b/tests/TestData/TestDoubles/RouterMock.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\TestData\TestDoubles;
+namespace Flexi\Test\TestData\TestDoubles;
 
-use CubaDevOps\Flexi\Infrastructure\Http\Route;
-use CubaDevOps\Flexi\Infrastructure\Http\Router;
+use Flexi\Infrastructure\Http\Route;
+use Flexi\Infrastructure\Http\Router;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 

--- a/tests/TestData/TestDoubles/ServicesArrayCache.php
+++ b/tests/TestData/TestDoubles/ServicesArrayCache.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\TestData\TestDoubles;
+namespace Flexi\Test\TestData\TestDoubles;
 
 use Flexi\Contracts\Interfaces\CacheInterface;
 

--- a/tests/TestData/TestDoubles/TestHttpHandler.php
+++ b/tests/TestData/TestDoubles/TestHttpHandler.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CubaDevOps\Flexi\Test\TestData\TestDoubles;
+namespace Flexi\Test\TestData\TestDoubles;
 
 use Flexi\Contracts\Classes\HttpHandler;
 use Psr\Http\Message\ResponseFactoryInterface;

--- a/tests/Unit/Domain/ValueObjects/ConfigurationTypeTest.php
+++ b/tests/Unit/Domain/ValueObjects/ConfigurationTypeTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Domain\ValueObjects;
 
-use CubaDevOps\Flexi\Domain\ValueObjects\ConfigurationType;
+use Flexi\Domain\ValueObjects\ConfigurationType;
 use PHPUnit\Framework\TestCase;
 use InvalidArgumentException;
 


### PR DESCRIPTION
This pull request completes a major namespace migration, renaming all occurrences of the old `CubaDevOps\Flexi` namespace to the new, simplified `Flexi` namespace across the entire codebase and documentation. This change affects composer configuration, code examples, service definitions, and all relevant documentation, ensuring consistency and alignment with the new project identity.

**Core namespace migration:**

* Updated the main package name in `composer.json` from `cubadevops/flexi` to `flexi/core` and changed all PSR-4 autoload mappings from `CubaDevOps\Flexi`. This pull request completes a major namespace migration, renaming all occurrences of the old `CubaDevOps\Flexi` namespace to the new, simplified `Flexi` namespace across the entire codebase and documentation. This change affects composer configuration, code examples, service definitions, and all relevant documentation, ensuring consistency and alignment with the new project identity.