### PR TITLE
feat: use module cache service on local module detector

### DIFF
--- a/src/Application/UseCase/ActivateModule.php
+++ b/src/Application/UseCase/ActivateModule.php
@@ -6,7 +6,7 @@ namespace Flexi\Application\UseCase;
 
 use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
 use Flexi\Domain\Interfaces\ModuleEnvironmentManagerInterface;
-use Flexi\Infrastructure\Factories\HybridModuleDetector;
+use Flexi\Infrastructure\Classes\HybridModuleDetector;
 use Flexi\Contracts\Classes\PlainTextMessage;
 use Flexi\Contracts\Interfaces\DTOInterface;
 use Flexi\Contracts\Interfaces\HandlerInterface;

--- a/src/Application/UseCase/DeactivateModule.php
+++ b/src/Application/UseCase/DeactivateModule.php
@@ -6,7 +6,7 @@ namespace Flexi\Application\UseCase;
 
 use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
 use Flexi\Domain\Interfaces\ModuleEnvironmentManagerInterface;
-use Flexi\Infrastructure\Factories\HybridModuleDetector;
+use Flexi\Infrastructure\Classes\HybridModuleDetector;
 use Flexi\Contracts\Classes\PlainTextMessage;
 use Flexi\Contracts\Interfaces\DTOInterface;
 use Flexi\Contracts\Interfaces\HandlerInterface;

--- a/src/Application/UseCase/UpdateModuleEnvironment.php
+++ b/src/Application/UseCase/UpdateModuleEnvironment.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Flexi\Application\UseCase;
 
 use Flexi\Domain\Interfaces\ModuleEnvironmentManagerInterface;
-use Flexi\Infrastructure\Factories\HybridModuleDetector;
+use Flexi\Infrastructure\Classes\HybridModuleDetector;
 use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
 use Flexi\Contracts\Classes\PlainTextMessage;
 use Flexi\Contracts\Interfaces\DTOInterface;

--- a/src/Config/services.json
+++ b/src/Config/services.json
@@ -132,18 +132,19 @@
       }
     },
     {
-      "name": "Flexi\\Infrastructure\\Factories\\LocalModuleDetector",
+      "name": "Flexi\\Infrastructure\\Classes\\LocalModuleDetector",
       "class": {
-        "name": "Flexi\\Infrastructure\\Factories\\LocalModuleDetector",
+        "name": "Flexi\\Infrastructure\\Classes\\LocalModuleDetector",
         "arguments": [
+          "@Flexi\\Domain\\Interfaces\\ModuleCacheManagerInterface",
           "./modules"
         ]
       }
     },
     {
-      "name": "Flexi\\Infrastructure\\Factories\\VendorModuleDetector",
+      "name": "Flexi\\Infrastructure\\Classes\\VendorModuleDetector",
       "class": {
-        "name": "Flexi\\Infrastructure\\Factories\\VendorModuleDetector",
+        "name": "Flexi\\Infrastructure\\Classes\\VendorModuleDetector",
         "arguments": [
           "@Flexi\\Domain\\Interfaces\\ModuleCacheManagerInterface",
           "./vendor"
@@ -151,18 +152,18 @@
       }
     },
     {
-      "name": "Flexi\\Infrastructure\\Factories\\HybridModuleDetector",
+      "name": "Flexi\\Infrastructure\\Classes\\HybridModuleDetector",
       "class": {
-        "name": "Flexi\\Infrastructure\\Factories\\HybridModuleDetector",
+        "name": "Flexi\\Infrastructure\\Classes\\HybridModuleDetector",
         "arguments": [
-          "@Flexi\\Infrastructure\\Factories\\LocalModuleDetector",
-          "@Flexi\\Infrastructure\\Factories\\VendorModuleDetector"
+          "@Flexi\\Infrastructure\\Classes\\LocalModuleDetector",
+          "@Flexi\\Infrastructure\\Classes\\VendorModuleDetector"
         ]
       }
     },
     {
       "name": "Flexi\\Domain\\Interfaces\\ModuleDetectorInterface",
-      "alias": "Flexi\\Infrastructure\\Factories\\HybridModuleDetector"
+      "alias": "Flexi\\Infrastructure\\Classes\\HybridModuleDetector"
     },
     {
       "name": "Flexi\\Domain\\Interfaces\\ModuleEnvironmentManagerInterface",
@@ -183,7 +184,7 @@
         "name": "Flexi\\Application\\UseCase\\ActivateModule",
         "arguments": [
           "@Flexi\\Domain\\Interfaces\\ModuleStateManagerInterface",
-          "@Flexi\\Infrastructure\\Factories\\HybridModuleDetector",
+          "@Flexi\\Infrastructure\\Classes\\HybridModuleDetector",
           "@Flexi\\Domain\\Interfaces\\ModuleEnvironmentManagerInterface"
         ]
       }
@@ -194,7 +195,7 @@
         "name": "Flexi\\Application\\UseCase\\DeactivateModule",
         "arguments": [
           "@Flexi\\Domain\\Interfaces\\ModuleStateManagerInterface",
-          "@Flexi\\Infrastructure\\Factories\\HybridModuleDetector",
+          "@Flexi\\Infrastructure\\Classes\\HybridModuleDetector",
           "@Flexi\\Domain\\Interfaces\\ModuleEnvironmentManagerInterface"
         ]
       }
@@ -205,7 +206,7 @@
         "name": "Flexi\\Application\\UseCase\\GetModuleStatus",
         "arguments": [
           "@Flexi\\Domain\\Interfaces\\ModuleStateManagerInterface",
-          "@Flexi\\Infrastructure\\Factories\\HybridModuleDetector"
+          "@Flexi\\Infrastructure\\Classes\\HybridModuleDetector"
         ]
       }
     },
@@ -215,7 +216,7 @@
         "name": "Flexi\\Application\\UseCase\\UpdateModuleEnvironment",
         "arguments": [
           "@Flexi\\Domain\\Interfaces\\ModuleEnvironmentManagerInterface",
-          "@Flexi\\Infrastructure\\Factories\\HybridModuleDetector",
+          "@Flexi\\Infrastructure\\Classes\\HybridModuleDetector",
           "@Flexi\\Domain\\Interfaces\\ModuleStateManagerInterface"
         ]
       }
@@ -226,7 +227,7 @@
         "name": "Flexi\\Application\\UseCase\\ListModules",
         "arguments": [
           "@Flexi\\Domain\\Interfaces\\ModuleStateManagerInterface",
-          "@Flexi\\Infrastructure\\Factories\\HybridModuleDetector"
+          "@Flexi\\Infrastructure\\Classes\\HybridModuleDetector"
         ]
       }
     },
@@ -236,7 +237,7 @@
         "name": "Flexi\\Infrastructure\\Classes\\ConfigurationFilesProvider",
         "arguments": [
           "@Flexi\\Domain\\Interfaces\\ModuleStateManagerInterface",
-          "@Flexi\\Infrastructure\\Factories\\HybridModuleDetector",
+          "@Flexi\\Infrastructure\\Classes\\HybridModuleDetector",
           "./"
         ]
       }

--- a/src/Domain/Interfaces/ModuleCacheManagerInterface.php
+++ b/src/Domain/Interfaces/ModuleCacheManagerInterface.php
@@ -15,19 +15,21 @@ use Flexi\Domain\ValueObjects\ModuleInfo;
 interface ModuleCacheManagerInterface
 {
     /**
-     * Get cached modules information.
+     * Get cached modules information for a specific type.
      *
+     * @param string|null $type Module type ('local', 'vendor', or null for all)
      * @return ModuleInfo[] Array of cached module information
      */
-    public function getCachedModules(): array;
+    public function getCachedModules(?string $type = null): array;
 
     /**
-     * Cache modules information.
+     * Cache modules information for a specific type.
      *
      * @param ModuleInfo[] $modules Array of modules to cache
+     * @param string $type Module type ('local' or 'vendor')
      * @return bool True if cache was successfully written
      */
-    public function cacheModules(array $modules): bool;
+    public function cacheModules(array $modules, string $type): bool;
 
     /**
      * Check if cache is valid based on composer.lock modification time.

--- a/src/Infrastructure/Classes/ConfigurationFilesProvider.php
+++ b/src/Infrastructure/Classes/ConfigurationFilesProvider.php
@@ -6,7 +6,7 @@ namespace Flexi\Infrastructure\Classes;
 
 use Flexi\Domain\Interfaces\ConfigurationFilesProviderInterface;
 use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
-use Flexi\Infrastructure\Factories\HybridModuleDetector;
+use Flexi\Infrastructure\Classes\HybridModuleDetector;
 use Flexi\Domain\ValueObjects\ModuleInfo;
 use Flexi\Domain\ValueObjects\ConfigurationType;
 use Flexi\Contracts\Classes\Traits\FileHandlerTrait;

--- a/src/Infrastructure/Classes/HybridModuleDetector.php
+++ b/src/Infrastructure/Classes/HybridModuleDetector.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Flexi\Infrastructure\Factories;
+namespace Flexi\Infrastructure\Classes;
 
 use Flexi\Domain\ValueObjects\ModuleInfo;
 use Flexi\Domain\ValueObjects\ModuleType;

--- a/src/Infrastructure/Classes/VendorModuleDetector.php
+++ b/src/Infrastructure/Classes/VendorModuleDetector.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Flexi\Infrastructure\Factories;
+namespace Flexi\Infrastructure\Classes;
 
 use Flexi\Domain\ValueObjects\ModuleInfo;
 use Flexi\Domain\ValueObjects\ModuleType;
@@ -149,22 +149,21 @@ class VendorModuleDetector implements ModuleDetectorInterface
             return null;
         }
 
-        $cachedModules = $this->cacheManager->getCachedModules();
+        $cachedModules = $this->cacheManager->getCachedModules('vendor');
         $indexedModules = [];
 
         foreach ($cachedModules as $module) {
-            if ($module->getType()->getValue() === 'vendor') {
-                $indexedModules[$module->getName()] = [
-                    'name' => $module->getName(),
-                    'package' => $module->getPackage(),
-                    'path' => $module->getPath(),
-                    'version' => $module->getVersion(),
-                    'metadata' => $module->getMetadata()
-                ];
-            }
+            $indexedModules[$module->getName()] = [
+                'name' => $module->getName(),
+                'package' => $module->getPackage(),
+                'path' => $module->getPath(),
+                'version' => $module->getVersion(),
+                'metadata' => $module->getMetadata()
+            ];
         }
 
-        return $indexedModules;
+        // If no vendor modules found in cache, treat it as cache miss
+        return empty($indexedModules) ? null : $indexedModules;
     }
 
     /**
@@ -172,7 +171,7 @@ class VendorModuleDetector implements ModuleDetectorInterface
      */
     private function saveToCache(array $discoveredModules): void
     {
-        // Convert to ModuleInfo objects for caching
+        // Convert discovered vendor modules to ModuleInfo objects
         $moduleInfos = [];
         foreach ($discoveredModules as $moduleData) {
             $moduleInfos[] = new ModuleInfo(
@@ -186,7 +185,7 @@ class VendorModuleDetector implements ModuleDetectorInterface
             );
         }
 
-        $this->cacheManager->cacheModules($moduleInfos);
+        $this->cacheManager->cacheModules($moduleInfos, 'vendor');
     }
 
     /**

--- a/src/Infrastructure/Factories/ContainerFactory.php
+++ b/src/Infrastructure/Factories/ContainerFactory.php
@@ -16,7 +16,10 @@ use Flexi\Infrastructure\DependencyInjection\Container;
 use Flexi\Domain\Interfaces\ConfigurationFilesProviderInterface;
 use Flexi\Domain\ValueObjects\ConfigurationType;
 use Flexi\Infrastructure\Classes\ConfigurationFilesProvider;
+use Flexi\Infrastructure\Classes\HybridModuleDetector;
+use Flexi\Infrastructure\Classes\LocalModuleDetector;
 use Flexi\Infrastructure\Classes\ModuleStateManager;
+use Flexi\Infrastructure\Classes\VendorModuleDetector;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 
@@ -71,7 +74,11 @@ class ContainerFactory
         $configurationRepository = new ConfigurationRepository();
         $configuration = new Configuration($configurationRepository);
         $modulesStateManager = new ModuleStateManager(new ModuleStateRepository("./var/modules-state.json"));
-        $moduleDetector = new HybridModuleDetector( new LocalModuleDetector(), new VendorModuleDetector(new ModuleCacheManager()));
+        $moduleCacheManager = new ModuleCacheManager();
+        $moduleDetector = new HybridModuleDetector(
+            new LocalModuleDetector($moduleCacheManager),
+            new VendorModuleDetector($moduleCacheManager)
+        );
         $cache = (new DefaultCacheFactory($moduleDetector, $configuration))->createCache();
         $objectBuilder = new ObjectBuilder($cache);
         $servicesDefinitionParser = new ServicesDefinitionParser($cache);

--- a/tests/Application/UseCase/ActivateModuleTest.php
+++ b/tests/Application/UseCase/ActivateModuleTest.php
@@ -9,7 +9,7 @@ use Flexi\Application\UseCase\ActivateModule;
 use Flexi\Domain\ValueObjects\ModuleInfo;
 use Flexi\Domain\ValueObjects\ModuleState;
 use Flexi\Domain\ValueObjects\ModuleType;
-use Flexi\Infrastructure\Factories\HybridModuleDetector;
+use Flexi\Infrastructure\Classes\HybridModuleDetector;
 use Flexi\Domain\Interfaces\ModuleEnvironmentManagerInterface;
 use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
 use DateTimeImmutable;

--- a/tests/Application/UseCase/DeactivateModuleTest.php
+++ b/tests/Application/UseCase/DeactivateModuleTest.php
@@ -9,7 +9,7 @@ use Flexi\Application\UseCase\DeactivateModule;
 use Flexi\Domain\ValueObjects\ModuleInfo;
 use Flexi\Domain\ValueObjects\ModuleState;
 use Flexi\Domain\ValueObjects\ModuleType;
-use Flexi\Infrastructure\Factories\HybridModuleDetector;
+use Flexi\Infrastructure\Classes\HybridModuleDetector;
 use Flexi\Domain\Interfaces\ModuleEnvironmentManagerInterface;
 use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
 use DateTimeImmutable;

--- a/tests/Application/UseCase/UpdateModuleEnvironmentTest.php
+++ b/tests/Application/UseCase/UpdateModuleEnvironmentTest.php
@@ -8,7 +8,7 @@ use Flexi\Application\Commands\UpdateModuleEnvironmentCommand;
 use Flexi\Application\UseCase\UpdateModuleEnvironment;
 use Flexi\Domain\ValueObjects\ModuleInfo;
 use Flexi\Domain\ValueObjects\ModuleType;
-use Flexi\Infrastructure\Factories\HybridModuleDetector;
+use Flexi\Infrastructure\Classes\HybridModuleDetector;
 use Flexi\Domain\Interfaces\ModuleEnvironmentManagerInterface;
 use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;

--- a/tests/Infrastructure/Classes/ConfigurationFilesProviderTest.php
+++ b/tests/Infrastructure/Classes/ConfigurationFilesProviderTest.php
@@ -8,7 +8,7 @@ use Flexi\Domain\ValueObjects\ConfigurationType;
 use Flexi\Domain\ValueObjects\ModuleInfo;
 use Flexi\Domain\ValueObjects\ModuleType;
 use Flexi\Infrastructure\Classes\ConfigurationFilesProvider;
-use Flexi\Infrastructure\Factories\HybridModuleDetector;
+use Flexi\Infrastructure\Classes\HybridModuleDetector;
 use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;

--- a/tests/Infrastructure/Classes/VendorModuleDetectorTest.php
+++ b/tests/Infrastructure/Classes/VendorModuleDetectorTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Flexi\Test\Infrastructure\Factories;
+namespace Flexi\Test\Infrastructure\Classes;
 
 use Flexi\Domain\ValueObjects\ModuleInfo;
 use Flexi\Domain\ValueObjects\ModuleType;
-use Flexi\Infrastructure\Factories\VendorModuleDetector;
+use Flexi\Infrastructure\Classes\VendorModuleDetector;
 use Flexi\Domain\Interfaces\ModuleCacheManagerInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -215,12 +215,19 @@ final class FakeCacheManager implements ModuleCacheManagerInterface
         $this->cacheFilePath = sys_get_temp_dir() . '/fake_cache_' . uniqid() . '.json';
     }
 
-    public function getCachedModules(): array
+    public function getCachedModules(?string $type = null): array
     {
-        return $this->cachedModules;
+        if ($type === null) {
+            return $this->cachedModules;
+        }
+
+        // Filter by type
+        return array_filter($this->cachedModules, function($module) use ($type) {
+            return $module->getType()->getValue() === $type;
+        });
     }
 
-    public function cacheModules(array $modules): bool
+    public function cacheModules(array $modules, string $type): bool
     {
         $this->cacheModulesCalls++;
         $this->cachedPayload = $modules;

--- a/tests/Infrastructure/Factories/ContainerFactoryTest.php
+++ b/tests/Infrastructure/Factories/ContainerFactoryTest.php
@@ -7,9 +7,10 @@ namespace Flexi\Test\Infrastructure\Factories;
 use Flexi\Infrastructure\Factories\ContainerFactory;
 use Flexi\Domain\Interfaces\ModuleDetectorInterface;
 use Flexi\Infrastructure\Factories\CacheFactoryInterface;
-use Flexi\Infrastructure\Factories\HybridModuleDetector;
-use Flexi\Infrastructure\Factories\LocalModuleDetector;
-use Flexi\Infrastructure\Factories\VendorModuleDetector;
+use Flexi\Infrastructure\Classes\HybridModuleDetector;
+use Flexi\Infrastructure\Classes\LocalModuleDetector;
+use Flexi\Infrastructure\Classes\VendorModuleDetector;
+use Flexi\Infrastructure\Classes\ModuleCacheManager;
 use Flexi\Infrastructure\Factories\DefaultCacheFactory;
 use Flexi\Infrastructure\DependencyInjection\Container;
 use Flexi\Infrastructure\DependencyInjection\ServicesDefinitionParser;
@@ -210,7 +211,8 @@ class ContainerFactoryTest extends TestCase
     public function testHybridModuleDetectorImplementation(): void
     {
         // Test the real implementation of HybridModuleDetector
-        $localDetector = new LocalModuleDetector('./tests/fixtures/modules');
+        $cacheManager = new ModuleCacheManager();
+        $localDetector = new LocalModuleDetector($cacheManager, './tests/fixtures/modules');
         $vendorDetector = $this->createMock(VendorModuleDetector::class);
         $detector = new HybridModuleDetector($localDetector, $vendorDetector);
 
@@ -260,7 +262,8 @@ class ContainerFactoryTest extends TestCase
     public function testHybridModuleDetectorCacheHandling(): void
     {
         // Test caching behavior
-        $localDetector = new LocalModuleDetector('./tests/fixtures/modules');
+        $cacheManager = new ModuleCacheManager();
+        $localDetector = new LocalModuleDetector($cacheManager, './tests/fixtures/modules');
         $vendorDetector = $this->createMock(VendorModuleDetector::class);
         $detector = new HybridModuleDetector($localDetector, $vendorDetector);
 
@@ -278,7 +281,8 @@ class ContainerFactoryTest extends TestCase
 
     public function testHybridModuleDetectorWithDifferentModules(): void
     {
-        $localDetector = new LocalModuleDetector('./tests/fixtures/modules');
+        $cacheManager = new ModuleCacheManager();
+        $localDetector = new LocalModuleDetector($cacheManager, './tests/fixtures/modules');
         $vendorDetector = $this->createMock(VendorModuleDetector::class);
         $detector = new HybridModuleDetector($localDetector, $vendorDetector);
 


### PR DESCRIPTION
## Description

This pull request refactors the module detection and caching system to improve clarity, extensibility, and performance. The main changes include moving module detector classes from the `Factories` namespace to `Classes`, updating dependency injection configuration, and enhancing the module cache to support storing and retrieving modules by type (e.g., local, vendor). Additionally, the local module detector now uses caching for improved efficiency.

These changes collectively improve the maintainability, scalability, and efficiency of the module detection and caching subsystems.

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- [x] Unit Tests
- [ ] Integration Tests

**Test Configuration**:
* Flexi version: dev
* PHP version: 7.4
* Operating System: Docker container

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
