### PR TITLE
feat: upgrade contracts dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "ext-json": "*",
     "ext-pcntl": "*",
     "cubadevops/upgrader": "^1.6",
-    "flexi/contracts": "^2.0",
+    "flexi/contracts": ">=4.1.0",
     "guzzlehttp/guzzle": "^7.7",
     "symfony/error-handler": "^5.4",
     "vlucas/phpdotenv": "^5.5"

--- a/tests/TestData/TestDoubles/Bus/RecordingListener.php
+++ b/tests/TestData/TestDoubles/Bus/RecordingListener.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Flexi\Test\TestData\TestDoubles\Bus;
 
+use Flexi\Contracts\Classes\PlainTextMessage;
 use Flexi\Contracts\Interfaces\DTOInterface;
 use Flexi\Contracts\Interfaces\EventInterface;
 use Flexi\Contracts\Interfaces\EventListenerInterface;
+use Flexi\Contracts\Interfaces\MessageInterface;
 
 class RecordingListener implements EventListenerInterface
 {
@@ -21,14 +23,16 @@ class RecordingListener implements EventListenerInterface
         $this->callback = $callback;
     }
 
-    public function handle(DTOInterface $dto)
+    public function handle(DTOInterface $dto): MessageInterface
     {
         if ($dto instanceof EventInterface) {
             $this->handleEvent($dto);
         }
+
+        return new PlainTextMessage('Event handled');
     }
 
-    public function handleEvent(EventInterface $event)
+    public function handleEvent(EventInterface $event): void
     {
         $this->received[] = $event;
 


### PR DESCRIPTION
This pull request updates the dependency requirements for `flexi/contracts` and refactors the `RecordingListener` test double to improve type safety and conformity with newer interfaces. The most important changes are grouped below:

Dependency updates:

* Updated the required version of `flexi/contracts` in `composer.json` to `>=4.1.0`, ensuring compatibility with newer features and interfaces.

Test double refactoring:

* Added imports for `PlainTextMessage` and `MessageInterface` in `RecordingListener.php` to support the new method signature and return type.
* Changed the signature of `handle` in `RecordingListener` to return a `MessageInterface`, and now returns a `PlainTextMessage` after handling an event, aligning with updated interface expectations.
* Updated the signature of `handleEvent` in `RecordingListener` to explicitly return `void`, improving clarity and type safety.