### PR TITLE
feat: adds cache to LocalModuleDetector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "ext-json": "*",
     "ext-pcntl": "*",
     "cubadevops/upgrader": "^1.6",
-    "flexi/contracts": "^2.0",
+    "flexi/contracts": ">=4.1.0",
     "guzzlehttp/guzzle": "^7.7",
     "symfony/error-handler": "^5.4",
     "vlucas/phpdotenv": "^5.5"

--- a/src/Application/UseCase/ActivateModule.php
+++ b/src/Application/UseCase/ActivateModule.php
@@ -6,7 +6,7 @@ namespace Flexi\Application\UseCase;
 
 use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
 use Flexi\Domain\Interfaces\ModuleEnvironmentManagerInterface;
-use Flexi\Infrastructure\Factories\HybridModuleDetector;
+use Flexi\Infrastructure\Classes\HybridModuleDetector;
 use Flexi\Contracts\Classes\PlainTextMessage;
 use Flexi\Contracts\Interfaces\DTOInterface;
 use Flexi\Contracts\Interfaces\HandlerInterface;

--- a/src/Application/UseCase/DeactivateModule.php
+++ b/src/Application/UseCase/DeactivateModule.php
@@ -6,7 +6,7 @@ namespace Flexi\Application\UseCase;
 
 use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
 use Flexi\Domain\Interfaces\ModuleEnvironmentManagerInterface;
-use Flexi\Infrastructure\Factories\HybridModuleDetector;
+use Flexi\Infrastructure\Classes\HybridModuleDetector;
 use Flexi\Contracts\Classes\PlainTextMessage;
 use Flexi\Contracts\Interfaces\DTOInterface;
 use Flexi\Contracts\Interfaces\HandlerInterface;

--- a/src/Application/UseCase/UpdateModuleEnvironment.php
+++ b/src/Application/UseCase/UpdateModuleEnvironment.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Flexi\Application\UseCase;
 
 use Flexi\Domain\Interfaces\ModuleEnvironmentManagerInterface;
-use Flexi\Infrastructure\Factories\HybridModuleDetector;
+use Flexi\Infrastructure\Classes\HybridModuleDetector;
 use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
 use Flexi\Contracts\Classes\PlainTextMessage;
 use Flexi\Contracts\Interfaces\DTOInterface;

--- a/src/Config/services.json
+++ b/src/Config/services.json
@@ -132,18 +132,19 @@
       }
     },
     {
-      "name": "Flexi\\Infrastructure\\Factories\\LocalModuleDetector",
+      "name": "Flexi\\Infrastructure\\Classes\\LocalModuleDetector",
       "class": {
-        "name": "Flexi\\Infrastructure\\Factories\\LocalModuleDetector",
+        "name": "Flexi\\Infrastructure\\Classes\\LocalModuleDetector",
         "arguments": [
+          "@Flexi\\Domain\\Interfaces\\ModuleCacheManagerInterface",
           "./modules"
         ]
       }
     },
     {
-      "name": "Flexi\\Infrastructure\\Factories\\VendorModuleDetector",
+      "name": "Flexi\\Infrastructure\\Classes\\VendorModuleDetector",
       "class": {
-        "name": "Flexi\\Infrastructure\\Factories\\VendorModuleDetector",
+        "name": "Flexi\\Infrastructure\\Classes\\VendorModuleDetector",
         "arguments": [
           "@Flexi\\Domain\\Interfaces\\ModuleCacheManagerInterface",
           "./vendor"
@@ -151,18 +152,18 @@
       }
     },
     {
-      "name": "Flexi\\Infrastructure\\Factories\\HybridModuleDetector",
+      "name": "Flexi\\Infrastructure\\Classes\\HybridModuleDetector",
       "class": {
-        "name": "Flexi\\Infrastructure\\Factories\\HybridModuleDetector",
+        "name": "Flexi\\Infrastructure\\Classes\\HybridModuleDetector",
         "arguments": [
-          "@Flexi\\Infrastructure\\Factories\\LocalModuleDetector",
-          "@Flexi\\Infrastructure\\Factories\\VendorModuleDetector"
+          "@Flexi\\Infrastructure\\Classes\\LocalModuleDetector",
+          "@Flexi\\Infrastructure\\Classes\\VendorModuleDetector"
         ]
       }
     },
     {
       "name": "Flexi\\Domain\\Interfaces\\ModuleDetectorInterface",
-      "alias": "Flexi\\Infrastructure\\Factories\\HybridModuleDetector"
+      "alias": "Flexi\\Infrastructure\\Classes\\HybridModuleDetector"
     },
     {
       "name": "Flexi\\Domain\\Interfaces\\ModuleEnvironmentManagerInterface",
@@ -183,7 +184,7 @@
         "name": "Flexi\\Application\\UseCase\\ActivateModule",
         "arguments": [
           "@Flexi\\Domain\\Interfaces\\ModuleStateManagerInterface",
-          "@Flexi\\Infrastructure\\Factories\\HybridModuleDetector",
+          "@Flexi\\Infrastructure\\Classes\\HybridModuleDetector",
           "@Flexi\\Domain\\Interfaces\\ModuleEnvironmentManagerInterface"
         ]
       }
@@ -194,7 +195,7 @@
         "name": "Flexi\\Application\\UseCase\\DeactivateModule",
         "arguments": [
           "@Flexi\\Domain\\Interfaces\\ModuleStateManagerInterface",
-          "@Flexi\\Infrastructure\\Factories\\HybridModuleDetector",
+          "@Flexi\\Infrastructure\\Classes\\HybridModuleDetector",
           "@Flexi\\Domain\\Interfaces\\ModuleEnvironmentManagerInterface"
         ]
       }
@@ -205,7 +206,7 @@
         "name": "Flexi\\Application\\UseCase\\GetModuleStatus",
         "arguments": [
           "@Flexi\\Domain\\Interfaces\\ModuleStateManagerInterface",
-          "@Flexi\\Infrastructure\\Factories\\HybridModuleDetector"
+          "@Flexi\\Infrastructure\\Classes\\HybridModuleDetector"
         ]
       }
     },
@@ -215,7 +216,7 @@
         "name": "Flexi\\Application\\UseCase\\UpdateModuleEnvironment",
         "arguments": [
           "@Flexi\\Domain\\Interfaces\\ModuleEnvironmentManagerInterface",
-          "@Flexi\\Infrastructure\\Factories\\HybridModuleDetector",
+          "@Flexi\\Infrastructure\\Classes\\HybridModuleDetector",
           "@Flexi\\Domain\\Interfaces\\ModuleStateManagerInterface"
         ]
       }
@@ -226,7 +227,7 @@
         "name": "Flexi\\Application\\UseCase\\ListModules",
         "arguments": [
           "@Flexi\\Domain\\Interfaces\\ModuleStateManagerInterface",
-          "@Flexi\\Infrastructure\\Factories\\HybridModuleDetector"
+          "@Flexi\\Infrastructure\\Classes\\HybridModuleDetector"
         ]
       }
     },
@@ -236,7 +237,7 @@
         "name": "Flexi\\Infrastructure\\Classes\\ConfigurationFilesProvider",
         "arguments": [
           "@Flexi\\Domain\\Interfaces\\ModuleStateManagerInterface",
-          "@Flexi\\Infrastructure\\Factories\\HybridModuleDetector",
+          "@Flexi\\Infrastructure\\Classes\\HybridModuleDetector",
           "./"
         ]
       }

--- a/src/Domain/Interfaces/ModuleCacheManagerInterface.php
+++ b/src/Domain/Interfaces/ModuleCacheManagerInterface.php
@@ -15,19 +15,21 @@ use Flexi\Domain\ValueObjects\ModuleInfo;
 interface ModuleCacheManagerInterface
 {
     /**
-     * Get cached modules information.
+     * Get cached modules information for a specific type.
      *
+     * @param string|null $type Module type ('local', 'vendor', or null for all)
      * @return ModuleInfo[] Array of cached module information
      */
-    public function getCachedModules(): array;
+    public function getCachedModules(?string $type = null): array;
 
     /**
-     * Cache modules information.
+     * Cache modules information for a specific type.
      *
      * @param ModuleInfo[] $modules Array of modules to cache
+     * @param string $type Module type ('local' or 'vendor')
      * @return bool True if cache was successfully written
      */
-    public function cacheModules(array $modules): bool;
+    public function cacheModules(array $modules, string $type): bool;
 
     /**
      * Check if cache is valid based on composer.lock modification time.

--- a/src/Infrastructure/Classes/ConfigurationFilesProvider.php
+++ b/src/Infrastructure/Classes/ConfigurationFilesProvider.php
@@ -6,7 +6,7 @@ namespace Flexi\Infrastructure\Classes;
 
 use Flexi\Domain\Interfaces\ConfigurationFilesProviderInterface;
 use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
-use Flexi\Infrastructure\Factories\HybridModuleDetector;
+use Flexi\Infrastructure\Classes\HybridModuleDetector;
 use Flexi\Domain\ValueObjects\ModuleInfo;
 use Flexi\Domain\ValueObjects\ConfigurationType;
 use Flexi\Contracts\Classes\Traits\FileHandlerTrait;

--- a/src/Infrastructure/Classes/HybridModuleDetector.php
+++ b/src/Infrastructure/Classes/HybridModuleDetector.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Flexi\Infrastructure\Factories;
+namespace Flexi\Infrastructure\Classes;
 
 use Flexi\Domain\ValueObjects\ModuleInfo;
 use Flexi\Domain\ValueObjects\ModuleType;

--- a/src/Infrastructure/Classes/VendorModuleDetector.php
+++ b/src/Infrastructure/Classes/VendorModuleDetector.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Flexi\Infrastructure\Factories;
+namespace Flexi\Infrastructure\Classes;
 
 use Flexi\Domain\ValueObjects\ModuleInfo;
 use Flexi\Domain\ValueObjects\ModuleType;
@@ -149,22 +149,21 @@ class VendorModuleDetector implements ModuleDetectorInterface
             return null;
         }
 
-        $cachedModules = $this->cacheManager->getCachedModules();
+        $cachedModules = $this->cacheManager->getCachedModules('vendor');
         $indexedModules = [];
 
         foreach ($cachedModules as $module) {
-            if ($module->getType()->getValue() === 'vendor') {
-                $indexedModules[$module->getName()] = [
-                    'name' => $module->getName(),
-                    'package' => $module->getPackage(),
-                    'path' => $module->getPath(),
-                    'version' => $module->getVersion(),
-                    'metadata' => $module->getMetadata()
-                ];
-            }
+            $indexedModules[$module->getName()] = [
+                'name' => $module->getName(),
+                'package' => $module->getPackage(),
+                'path' => $module->getPath(),
+                'version' => $module->getVersion(),
+                'metadata' => $module->getMetadata()
+            ];
         }
 
-        return $indexedModules;
+        // If no vendor modules found in cache, treat it as cache miss
+        return empty($indexedModules) ? null : $indexedModules;
     }
 
     /**
@@ -172,7 +171,7 @@ class VendorModuleDetector implements ModuleDetectorInterface
      */
     private function saveToCache(array $discoveredModules): void
     {
-        // Convert to ModuleInfo objects for caching
+        // Convert discovered vendor modules to ModuleInfo objects
         $moduleInfos = [];
         foreach ($discoveredModules as $moduleData) {
             $moduleInfos[] = new ModuleInfo(
@@ -186,7 +185,7 @@ class VendorModuleDetector implements ModuleDetectorInterface
             );
         }
 
-        $this->cacheManager->cacheModules($moduleInfos);
+        $this->cacheManager->cacheModules($moduleInfos, 'vendor');
     }
 
     /**

--- a/src/Infrastructure/Factories/ContainerFactory.php
+++ b/src/Infrastructure/Factories/ContainerFactory.php
@@ -16,7 +16,10 @@ use Flexi\Infrastructure\DependencyInjection\Container;
 use Flexi\Domain\Interfaces\ConfigurationFilesProviderInterface;
 use Flexi\Domain\ValueObjects\ConfigurationType;
 use Flexi\Infrastructure\Classes\ConfigurationFilesProvider;
+use Flexi\Infrastructure\Classes\HybridModuleDetector;
+use Flexi\Infrastructure\Classes\LocalModuleDetector;
 use Flexi\Infrastructure\Classes\ModuleStateManager;
+use Flexi\Infrastructure\Classes\VendorModuleDetector;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 
@@ -71,7 +74,11 @@ class ContainerFactory
         $configurationRepository = new ConfigurationRepository();
         $configuration = new Configuration($configurationRepository);
         $modulesStateManager = new ModuleStateManager(new ModuleStateRepository("./var/modules-state.json"));
-        $moduleDetector = new HybridModuleDetector( new LocalModuleDetector(), new VendorModuleDetector(new ModuleCacheManager()));
+        $moduleCacheManager = new ModuleCacheManager();
+        $moduleDetector = new HybridModuleDetector(
+            new LocalModuleDetector($moduleCacheManager),
+            new VendorModuleDetector($moduleCacheManager)
+        );
         $cache = (new DefaultCacheFactory($moduleDetector, $configuration))->createCache();
         $objectBuilder = new ObjectBuilder($cache);
         $servicesDefinitionParser = new ServicesDefinitionParser($cache);

--- a/tests/Application/UseCase/ActivateModuleTest.php
+++ b/tests/Application/UseCase/ActivateModuleTest.php
@@ -9,7 +9,7 @@ use Flexi\Application\UseCase\ActivateModule;
 use Flexi\Domain\ValueObjects\ModuleInfo;
 use Flexi\Domain\ValueObjects\ModuleState;
 use Flexi\Domain\ValueObjects\ModuleType;
-use Flexi\Infrastructure\Factories\HybridModuleDetector;
+use Flexi\Infrastructure\Classes\HybridModuleDetector;
 use Flexi\Domain\Interfaces\ModuleEnvironmentManagerInterface;
 use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
 use DateTimeImmutable;

--- a/tests/Application/UseCase/DeactivateModuleTest.php
+++ b/tests/Application/UseCase/DeactivateModuleTest.php
@@ -9,7 +9,7 @@ use Flexi\Application\UseCase\DeactivateModule;
 use Flexi\Domain\ValueObjects\ModuleInfo;
 use Flexi\Domain\ValueObjects\ModuleState;
 use Flexi\Domain\ValueObjects\ModuleType;
-use Flexi\Infrastructure\Factories\HybridModuleDetector;
+use Flexi\Infrastructure\Classes\HybridModuleDetector;
 use Flexi\Domain\Interfaces\ModuleEnvironmentManagerInterface;
 use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
 use DateTimeImmutable;

--- a/tests/Application/UseCase/UpdateModuleEnvironmentTest.php
+++ b/tests/Application/UseCase/UpdateModuleEnvironmentTest.php
@@ -8,7 +8,7 @@ use Flexi\Application\Commands\UpdateModuleEnvironmentCommand;
 use Flexi\Application\UseCase\UpdateModuleEnvironment;
 use Flexi\Domain\ValueObjects\ModuleInfo;
 use Flexi\Domain\ValueObjects\ModuleType;
-use Flexi\Infrastructure\Factories\HybridModuleDetector;
+use Flexi\Infrastructure\Classes\HybridModuleDetector;
 use Flexi\Domain\Interfaces\ModuleEnvironmentManagerInterface;
 use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;

--- a/tests/Infrastructure/Classes/ConfigurationFilesProviderTest.php
+++ b/tests/Infrastructure/Classes/ConfigurationFilesProviderTest.php
@@ -8,7 +8,7 @@ use Flexi\Domain\ValueObjects\ConfigurationType;
 use Flexi\Domain\ValueObjects\ModuleInfo;
 use Flexi\Domain\ValueObjects\ModuleType;
 use Flexi\Infrastructure\Classes\ConfigurationFilesProvider;
-use Flexi\Infrastructure\Factories\HybridModuleDetector;
+use Flexi\Infrastructure\Classes\HybridModuleDetector;
 use Flexi\Domain\Interfaces\ModuleStateManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;

--- a/tests/Infrastructure/Classes/VendorModuleDetectorTest.php
+++ b/tests/Infrastructure/Classes/VendorModuleDetectorTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Flexi\Test\Infrastructure\Factories;
+namespace Flexi\Test\Infrastructure\Classes;
 
 use Flexi\Domain\ValueObjects\ModuleInfo;
 use Flexi\Domain\ValueObjects\ModuleType;
-use Flexi\Infrastructure\Factories\VendorModuleDetector;
+use Flexi\Infrastructure\Classes\VendorModuleDetector;
 use Flexi\Domain\Interfaces\ModuleCacheManagerInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -215,12 +215,19 @@ final class FakeCacheManager implements ModuleCacheManagerInterface
         $this->cacheFilePath = sys_get_temp_dir() . '/fake_cache_' . uniqid() . '.json';
     }
 
-    public function getCachedModules(): array
+    public function getCachedModules(?string $type = null): array
     {
-        return $this->cachedModules;
+        if ($type === null) {
+            return $this->cachedModules;
+        }
+
+        // Filter by type
+        return array_filter($this->cachedModules, function($module) use ($type) {
+            return $module->getType()->getValue() === $type;
+        });
     }
 
-    public function cacheModules(array $modules): bool
+    public function cacheModules(array $modules, string $type): bool
     {
         $this->cacheModulesCalls++;
         $this->cachedPayload = $modules;

--- a/tests/Infrastructure/Factories/ContainerFactoryTest.php
+++ b/tests/Infrastructure/Factories/ContainerFactoryTest.php
@@ -7,9 +7,10 @@ namespace Flexi\Test\Infrastructure\Factories;
 use Flexi\Infrastructure\Factories\ContainerFactory;
 use Flexi\Domain\Interfaces\ModuleDetectorInterface;
 use Flexi\Infrastructure\Factories\CacheFactoryInterface;
-use Flexi\Infrastructure\Factories\HybridModuleDetector;
-use Flexi\Infrastructure\Factories\LocalModuleDetector;
-use Flexi\Infrastructure\Factories\VendorModuleDetector;
+use Flexi\Infrastructure\Classes\HybridModuleDetector;
+use Flexi\Infrastructure\Classes\LocalModuleDetector;
+use Flexi\Infrastructure\Classes\VendorModuleDetector;
+use Flexi\Infrastructure\Classes\ModuleCacheManager;
 use Flexi\Infrastructure\Factories\DefaultCacheFactory;
 use Flexi\Infrastructure\DependencyInjection\Container;
 use Flexi\Infrastructure\DependencyInjection\ServicesDefinitionParser;
@@ -210,7 +211,8 @@ class ContainerFactoryTest extends TestCase
     public function testHybridModuleDetectorImplementation(): void
     {
         // Test the real implementation of HybridModuleDetector
-        $localDetector = new LocalModuleDetector('./tests/fixtures/modules');
+        $cacheManager = new ModuleCacheManager();
+        $localDetector = new LocalModuleDetector($cacheManager, './tests/fixtures/modules');
         $vendorDetector = $this->createMock(VendorModuleDetector::class);
         $detector = new HybridModuleDetector($localDetector, $vendorDetector);
 
@@ -260,7 +262,8 @@ class ContainerFactoryTest extends TestCase
     public function testHybridModuleDetectorCacheHandling(): void
     {
         // Test caching behavior
-        $localDetector = new LocalModuleDetector('./tests/fixtures/modules');
+        $cacheManager = new ModuleCacheManager();
+        $localDetector = new LocalModuleDetector($cacheManager, './tests/fixtures/modules');
         $vendorDetector = $this->createMock(VendorModuleDetector::class);
         $detector = new HybridModuleDetector($localDetector, $vendorDetector);
 
@@ -278,7 +281,8 @@ class ContainerFactoryTest extends TestCase
 
     public function testHybridModuleDetectorWithDifferentModules(): void
     {
-        $localDetector = new LocalModuleDetector('./tests/fixtures/modules');
+        $cacheManager = new ModuleCacheManager();
+        $localDetector = new LocalModuleDetector($cacheManager, './tests/fixtures/modules');
         $vendorDetector = $this->createMock(VendorModuleDetector::class);
         $detector = new HybridModuleDetector($localDetector, $vendorDetector);
 

--- a/tests/TestData/TestDoubles/Bus/RecordingListener.php
+++ b/tests/TestData/TestDoubles/Bus/RecordingListener.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Flexi\Test\TestData\TestDoubles\Bus;
 
+use Flexi\Contracts\Classes\PlainTextMessage;
 use Flexi\Contracts\Interfaces\DTOInterface;
 use Flexi\Contracts\Interfaces\EventInterface;
 use Flexi\Contracts\Interfaces\EventListenerInterface;
+use Flexi\Contracts\Interfaces\MessageInterface;
 
 class RecordingListener implements EventListenerInterface
 {
@@ -21,14 +23,16 @@ class RecordingListener implements EventListenerInterface
         $this->callback = $callback;
     }
 
-    public function handle(DTOInterface $dto)
+    public function handle(DTOInterface $dto): MessageInterface
     {
         if ($dto instanceof EventInterface) {
             $this->handleEvent($dto);
         }
+
+        return new PlainTextMessage('Event handled');
     }
 
-    public function handleEvent(EventInterface $event)
+    public function handleEvent(EventInterface $event): void
     {
         $this->received[] = $event;
 


### PR DESCRIPTION
This pull request introduces significant improvements to module detection and caching within the Flexi application. The main changes are the migration of module detector classes from the `Factories` namespace to `Classes`, the addition of type-aware module caching, and enhanced dependency injection for module detectors. These updates improve code organization, caching efficiency, and maintainability.

### Module Detector Refactoring

* Renamed and moved `HybridModuleDetector`, `LocalModuleDetector`, and `VendorModuleDetector` from the `Factories` namespace to the `Classes` namespace, updating all references and dependency injection aliases in `services.json` accordingly. [[1]](diffhunk://#diff-2f40a5f8bce21990ffbab2de194980538ff78717db40a3d5a272afd875197af1L135-R166) [[2]](diffhunk://#diff-b0cb704a4d014d3c9de1c7fcf35c9753c649302b07235143b5d47f9b94136079L5-R5) [[3]](diffhunk://#diff-4fe2e1f70cab25d47f32118615971e71c04e7e58ce99d39cd6c0d47ef2729badL5-R9)

### Type-Aware Module Caching

* Updated `ModuleCacheManagerInterface` and its implementation to support caching and retrieval of modules by type (`local`, `vendor`, or all). This includes changes to method signatures, cache file structure, and logic for reading/writing cache data. [[1]](diffhunk://#diff-736fd721b6c0193ababb7f47ce96c9c4601a93d628b0bc16780813d7251f477eL18-R32) [[2]](diffhunk://#diff-23e874e925fad2089ccfd2b8fb8730a981821cc4d140d4a64f2dec7d1604bf76L30-R34) [[3]](diffhunk://#diff-23e874e925fad2089ccfd2b8fb8730a981821cc4d140d4a64f2dec7d1604bf76L46-R73) [[4]](diffhunk://#diff-23e874e925fad2089ccfd2b8fb8730a981821cc4d140d4a64f2dec7d1604bf76L63-R88) [[5]](diffhunk://#diff-23e874e925fad2089ccfd2b8fb8730a981821cc4d140d4a64f2dec7d1604bf76L74-R112) [[6]](diffhunk://#diff-23e874e925fad2089ccfd2b8fb8730a981821cc4d140d4a64f2dec7d1604bf76R185-R224)

### Dependency Injection and Constructor Changes

* Modified constructors for `LocalModuleDetector` and related classes to inject `ModuleCacheManagerInterface`, enabling detectors to use the cache for improved performance and reliability. Updated service definitions in `services.json` to provide the correct dependencies. [[1]](diffhunk://#diff-4fe2e1f70cab25d47f32118615971e71c04e7e58ce99d39cd6c0d47ef2729badR21-R29) [[2]](diffhunk://#diff-2f40a5f8bce21990ffbab2de194980538ff78717db40a3d5a272afd875197af1L135-R166)

### Local Module Detection and Caching Logic

* Enhanced `LocalModuleDetector` to load modules from cache when available and valid, and to save discovered modules to cache after scanning. Added cache invalidation and refresh logic for accurate module discovery. [[1]](diffhunk://#diff-4fe2e1f70cab25d47f32118615971e71c04e7e58ce99d39cd6c0d47ef2729badR126-R132) [[2]](diffhunk://#diff-4fe2e1f70cab25d47f32118615971e71c04e7e58ce99d39cd6c0d47ef2729badR160-R162) [[3]](diffhunk://#diff-4fe2e1f70cab25d47f32118615971e71c04e7e58ce99d39cd6c0d47ef2729badR302-R358)

### Miscellaneous Updates

* Updated the default package name for local modules from `cubadevops/flexi-module-...` to `flexi/flexi-module-...` for consistency.
* Updated the required version of `flexi/contracts` in `composer.json` to `>=4.1.0` to ensure compatibility with new features.